### PR TITLE
(feat) Add column info to section properties

### DIFF
--- a/src/properties/section-properties.test.ts
+++ b/src/properties/section-properties.test.ts
@@ -60,7 +60,8 @@ describe('Section column formatting for equally sized columns', () => {
 				numberOfColumns: 3,
 				equalWidth: true,
 				separator: false,
-				columns: []
+				columnSpace: twip(720),
+				columnDefs: []
 			}
 		}
 	);
@@ -71,7 +72,7 @@ describe('Section column formatting for equally sized columns', () => {
 describe('Section column formatting for differently sized columns', () => { 
 	test(
 		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
-			<w:cols w:num="3" w:equalwidth="0" w:sep="1">
+			<w:cols w:num="3" w:equalwidth="0" w:sep="1" w:space="720" >
 				<w:col w:w="1440" w:space="720"/> 
 				<w:col w:w="1440" w:space="720" /> 
 				<w:col w:w="2880" /> 
@@ -82,7 +83,8 @@ describe('Section column formatting for differently sized columns', () => {
 				numberOfColumns: 3,
 				equalWidth: false,
 				separator: true,
-				columns: [
+				columnSpace: twip(720),
+				columnDefs: [
 					{columnWidth: twip(1440), columnSpace: twip(720)},
 					{columnWidth: twip(1440), columnSpace: twip(720)},
 					{columnWidth: twip(2880)}
@@ -91,6 +93,22 @@ describe('Section column formatting for differently sized columns', () => {
 		}
 	);
 });
+
+describe('Section column formatting for with missing properties', () => { 
+
+	expect(
+		sectionPropertiesToNode(
+		{ 
+			columns: { 
+				numberOfColumns: 3, 
+				equalWidth: false
+			}
+		})).toBe(
+		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
+			<w:cols w:num="3" w:equalwidth="false" />
+		</w:sectPr>`
+	)
+}); 
 
 describe('Section header/footer references', () => {
 	test(

--- a/src/properties/section-properties.test.ts
+++ b/src/properties/section-properties.test.ts
@@ -60,7 +60,7 @@ describe('Section column formatting for equally sized columns', () => {
 				numberOfColumns: 3,
 				equalWidth: true,
 				separator: false,
-				columnSpacing: twip(720)
+				columns: []
 			}
 		}
 	);
@@ -71,7 +71,7 @@ describe('Section column formatting for equally sized columns', () => {
 describe('Section column formatting for differently sized columns', () => { 
 	test(
 		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
-			<w:cols w:num="3" w:equalwidth="0" w:sep="0">
+			<w:cols w:num="3" w:equalwidth="0" w:sep="1">
 				<w:col w:w="1440" w:space="720"/> 
 				<w:col w:w="1440" w:space="720" /> 
 				<w:col w:w="2880" /> 
@@ -83,9 +83,9 @@ describe('Section column formatting for differently sized columns', () => {
 				equalWidth: false,
 				separator: true,
 				columns: [
-					{columnSize: twip(1440), columnSpacing: twip(720)},
-					{columnSize: twip(1440), columnSpacing: twip(720)},
-					{columnSize: twip(1440), columnSpacing: null}
+					{columnWidth: twip(1440), columnSpace: twip(720)},
+					{columnWidth: twip(1440), columnSpace: twip(720)},
+					{columnWidth: twip(2880)}
 				]
 			}
 		}

--- a/src/properties/section-properties.test.ts
+++ b/src/properties/section-properties.test.ts
@@ -3,17 +3,24 @@ import { describe } from 'std/testing/bdd';
 
 import { twip } from '../utilities/length.ts';
 import { ALL_NAMESPACE_DECLARATIONS } from '../utilities/namespaces.ts';
-import { createXmlRoundRobinTest } from '../utilities/tests.ts';
+import { createXmlRoundRobinTest, createObjectRoundRobinTest } from '../utilities/tests.ts';
 import {
 	SectionProperties,
 	sectionPropertiesFromNode,
 	sectionPropertiesToNode,
 } from './section-properties.ts';
+import { Node } from "https://esm.sh/v121/fontoxpath@3.28.2/dist/fontoxpath.d.ts";
 
 const test = createXmlRoundRobinTest<SectionProperties>(
 	sectionPropertiesFromNode,
 	sectionPropertiesToNode,
 );
+
+
+const reverseTest = createObjectRoundRobinTest<SectionProperties>(
+	sectionPropertiesToNode,
+	sectionPropertiesFromNode
+); 
 
 describe('Section formatting', () => {
 	test(
@@ -96,16 +103,15 @@ describe('Section column formatting for differently sized columns', () => {
 
 describe('Section column formatting for with missing properties', () => { 
 
-	expect(
-		sectionPropertiesToNode(
+		reverseTest(
 		{ 
 			columns: { 
-				numberOfColumns: 3, 
-				equalWidth: false
+				numberOfColumns: 3,
+				equalWidth: true
 			}
-		})).toBe(
+		}, 
 		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
-			<w:cols w:num="3" w:equalwidth="false" />
+			<w:cols w:num="3" w:equalwidth="1" /> 
 		</w:sectPr>`
 	)
 }); 

--- a/src/properties/section-properties.test.ts
+++ b/src/properties/section-properties.test.ts
@@ -23,15 +23,15 @@ describe('Section formatting', () => {
 				w:h="1600"
 				w:orient="landscape"
 			/>
-					<w:pgMar
-						w:top="1000"
-						w:right="1000"
-						w:bottom="1000"
-						w:left="1000"
-						w:header="1000"
-						w:footer="1000"
-						w:gutter="1000"
-					/>
+			<w:pgMar
+				w:top="1000"
+				w:right="1000"
+				w:bottom="1000"
+				w:left="1000"
+				w:header="1000"
+				w:footer="1000"
+				w:gutter="1000"
+			/>
 		</w:sectPr>`,
 		{
 			pageWidth: twip(1200),
@@ -47,6 +47,48 @@ describe('Section formatting', () => {
 				gutter: twip(1000),
 			},
 		},
+	);
+});
+
+describe('Section column formatting for equally sized columns', () => { 
+	test(
+		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
+			<w:cols w:num="3" w:equalwidth="1" w:sep="0" w:space="720"/> 
+		</w:sectPr>`,
+		{
+			columns: {
+				numberOfColumns: 3,
+				equalWidth: true,
+				separator: false,
+				columnSpacing: twip(720)
+			}
+		}
+	);
+});
+
+
+
+describe('Section column formatting for differently sized columns', () => { 
+	test(
+		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
+			<w:cols w:num="3" w:equalwidth="0" w:sep="0">
+				<w:col w:w="1440" w:space="720"/> 
+				<w:col w:w="1440" w:space="720" /> 
+				<w:col w:w="2880" /> 
+			</w:cols> 
+		</w:sectPr>`,
+		{
+			columns: {
+				numberOfColumns: 3,
+				equalWidth: false,
+				separator: true,
+				columns: [
+					{columnSize: twip(1440), columnSpacing: twip(720)},
+					{columnSize: twip(1440), columnSpacing: twip(720)},
+					{columnSize: twip(1440), columnSpacing: null}
+				]
+			}
+		}
 	);
 });
 

--- a/src/properties/section-properties.test.ts
+++ b/src/properties/section-properties.test.ts
@@ -1,26 +1,26 @@
-import { describe } from 'std/testing/bdd'; 
-
+import { describe } from 'std/testing/bdd';
 
 import { twip } from '../utilities/length.ts';
 import { ALL_NAMESPACE_DECLARATIONS } from '../utilities/namespaces.ts';
-import { createXmlRoundRobinTest, createObjectRoundRobinTest } from '../utilities/tests.ts';
+import {
+	createObjectRoundRobinTest,
+	createXmlRoundRobinTest,
+} from '../utilities/tests.ts';
 import {
 	SectionProperties,
 	sectionPropertiesFromNode,
 	sectionPropertiesToNode,
 } from './section-properties.ts';
-import { Node } from "https://esm.sh/v121/fontoxpath@3.28.2/dist/fontoxpath.d.ts";
 
 const test = createXmlRoundRobinTest<SectionProperties>(
 	sectionPropertiesFromNode,
-	sectionPropertiesToNode,
+	sectionPropertiesToNode
 );
-
 
 const reverseTest = createObjectRoundRobinTest<SectionProperties>(
 	sectionPropertiesToNode,
 	sectionPropertiesFromNode
-); 
+);
 
 describe('Section formatting', () => {
 	test(
@@ -53,11 +53,11 @@ describe('Section formatting', () => {
 				footer: twip(1000),
 				gutter: twip(1000),
 			},
-		},
+		}
 	);
 });
 
-describe('Section column formatting for equally sized columns', () => { 
+describe('Section column formatting for equally sized columns', () => {
 	test(
 		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
 			<w:cols w:num="3" w:equalwidth="1" w:sep="0" w:space="720"/> 
@@ -68,15 +68,13 @@ describe('Section column formatting for equally sized columns', () => {
 				equalWidth: true,
 				separator: false,
 				columnSpace: twip(720),
-				columnDefs: []
-			}
+				columnDefs: [],
+			},
 		}
 	);
 });
 
-
-
-describe('Section column formatting for differently sized columns', () => { 
+describe('Section column formatting for differently sized columns', () => {
 	test(
 		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
 			<w:cols w:num="3" w:equalwidth="0" w:sep="1" w:space="720" >
@@ -92,29 +90,45 @@ describe('Section column formatting for differently sized columns', () => {
 				separator: true,
 				columnSpace: twip(720),
 				columnDefs: [
-					{columnWidth: twip(1440), columnSpace: twip(720)},
-					{columnWidth: twip(1440), columnSpace: twip(720)},
-					{columnWidth: twip(2880)}
-				]
-			}
+					{ columnWidth: twip(1440), columnSpace: twip(720) },
+					{ columnWidth: twip(1440), columnSpace: twip(720) },
+					{ columnWidth: twip(2880) },
+				],
+			},
 		}
 	);
 });
 
-describe('Section column formatting for with missing properties', () => { 
-
-		reverseTest(
-		{ 
-			columns: { 
+describe('Section column formatting for with missing properties', () => {
+	reverseTest(
+		{
+			columns: {
 				numberOfColumns: 3,
-				equalWidth: true
-			}
-		}, 
+				equalWidth: true,
+			},
+		},
 		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
 			<w:cols w:num="3" w:equalwidth="1" /> 
 		</w:sectPr>`
-	)
-}); 
+	);
+
+	reverseTest(
+		{
+			columns: {
+				columnDefs: [
+					{ columnWidth: twip(1440), columnSpace: twip(720) },
+					{ columnWidth: twip(1440) },
+				],
+			},
+		},
+		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
+			<w:cols w:num="2" w:equalwidth="0"> 
+				<w:col w:w="1440" w:space="720" /> 
+				<w:col w:w="1440"/> 
+			</w:cols>
+		</w:sectPr>`
+	);
+});
 
 describe('Section header/footer references', () => {
 	test(
@@ -134,7 +148,7 @@ describe('Section header/footer references', () => {
 				even: null,
 				odd: null,
 			},
-		},
+		}
 	);
 });
 
@@ -144,7 +158,7 @@ describe('Section titlePg', () => {
 		</w:sectPr>`,
 		{
 			isTitlePage: false,
-		},
+		}
 	);
 	test(
 		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
@@ -152,7 +166,7 @@ describe('Section titlePg', () => {
 		</w:sectPr>`,
 		{
 			isTitlePage: true,
-		},
+		}
 	);
 	test(
 		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
@@ -160,7 +174,7 @@ describe('Section titlePg', () => {
 		</w:sectPr>`,
 		{
 			isTitlePage: true,
-		},
+		}
 	);
 	test(
 		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
@@ -168,6 +182,6 @@ describe('Section titlePg', () => {
 		</w:sectPr>`,
 		{
 			isTitlePage: false,
-		},
+		}
 	);
 });

--- a/src/properties/section-properties.ts
+++ b/src/properties/section-properties.ts
@@ -4,43 +4,55 @@ import { QNS } from '../utilities/namespaces.ts';
 import { evaluateXPathToMap } from '../utilities/xquery.ts';
 
 /**
- * Formatting options that are applied on the Section level. 
+ * Formatting options that are applied on the Section level.
  * For more on how OOXML secitons are structured: http://officeopenxml.com/WPsection.php
  */
 
 export type SectionProperties = {
 	/**
-	 * The column layout for this section. 
+	 * The column layout for this section.
 	 */
 	columns?: {
 		/**
-		 * The number of columns in a section of text. If  this property is present it must 
+		 * The number of columns in a section of text. If  this property is present it must
 		 * be an integer greater than 0 and less than or equal to 45.
 		 */
 		numberOfColumns?: number;
+		/**
+		 * Specifies whether all columns are of equal width.
+		 */
 		equalWidth?: boolean;
+		/**
+		 * Specifies whether a vertical line is to be drawn between each column. If set to true, then the line is drawn in the center of the space between the columns.
+		 */
 		separator?: boolean;
 		/**
-		 * The width of a column of text. If an array of columns is provided in the `columnDefs` 
+		 * The width of a column of text. If an array of columns is provided in the `columnDefs`
 		 * property, then this value is ignored.
 		 */
-		columnSpace?: Length; 
+		columnSpace?: Length;
 		/**
 		 * To create sections that use columns of different widths or uneven spacing, you can define
-		 * columns as an array of objects. This is _only_ used by Word if the `equalWidth` 
-		 * property is not true. 
+		 * columns as an array of objects. This is _only_ used by Word if the `equalWidth`
+		 * property is not true.
 		 */
-		columnDefs?: {columnWidth: Length, columnSpace?: Length }[]; 
-	}; 
+		columnDefs?: { columnWidth: Length; columnSpace?: Length }[];
+	};
 
 	/**
 	 * A reference to the header portion on every page in this section.
 	 */
-	headers?: null | string | { first?: string | null; even?: string | null; odd?: string | null };
+	headers?:
+		| null
+		| string
+		| { first?: string | null; even?: string | null; odd?: string | null };
 	/**
 	 * A reference to the footer portion on every page in this section.
 	 */
-	footers?: null | string | { first?: string | null; even?: string | null; odd?: string | null };
+	footers?:
+		| null
+		| string
+		| { first?: string | null; even?: string | null; odd?: string | null };
 	/**
 	 * The width of any page in this section.
 	 */
@@ -66,17 +78,19 @@ export type SectionProperties = {
 		header?: null | Length;
 		footer?: null | Length;
 		gutter?: null | Length;
-	}
+	};
 	/**
 	 * Specifies whether sections in the document shall have different headers and footers for even and odd pages.
 	 */
 	isTitlePage?: null | boolean;
 };
 
-export function sectionPropertiesFromNode(node?: Node | null): SectionProperties {
+export function sectionPropertiesFromNode(
+	node?: Node | null
+): SectionProperties {
 	if (!node) {
 		return {};
-	};
+	}
 
 	return evaluateXPathToMap<SectionProperties>(
 		`map {
@@ -116,12 +130,11 @@ export function sectionPropertiesFromNode(node?: Node | null): SectionProperties
 			},
 			"isTitlePage": exists(./${QNS.w}titlePg) and (not(./${QNS.w}titlePg/@${QNS.w}val) or docxml:st-on-off(./${QNS.w}titlePg/@${QNS.w}val))
 		}`,
-		node,
+		node
 	);
 }
 
 export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
-
 	return create(
 		`element ${QNS.w}sectPr {
 			if (exists($headers('first'))) then element ${QNS.w}headerReference {
@@ -212,11 +225,19 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 		{
 			headers:
 				typeof data.headers === 'string'
-					? { first: data.headers, even: data.headers, odd: data.headers }
+					? {
+							first: data.headers,
+							even: data.headers,
+							odd: data.headers,
+					  }
 					: data.headers || {},
 			footers:
 				typeof data.footers === 'string'
-					? { first: data.footers, even: data.footers, odd: data.footers }
+					? {
+							first: data.footers,
+							even: data.footers,
+							odd: data.footers,
+					  }
 					: data.footers || {},
 			columns: data.columns || {},
 			pageWidth: data.pageWidth || null,

--- a/src/properties/section-properties.ts
+++ b/src/properties/section-properties.ts
@@ -4,20 +4,33 @@ import { QNS } from '../utilities/namespaces.ts';
 import { evaluateXPathToMap } from '../utilities/xquery.ts';
 
 /**
- * All the formatting options that can be given on a text run (inline text).
- *
- * Serializes to the <w:rPr> element.
- *   https://c-rex.net/projects/samples/ooxml/e1/Part4/OOXML_P4_DOCX_rPr_topic_ID0EIEKM.html
+ * Formatting options that are applied on the Section level. 
+ * For more on how OOXML secitons are structured: http://officeopenxml.com/WPsection.php
  */
+
 export type SectionProperties = {
 	/**
-	 * The column layout for a particular section of the document
+	 * The column layout for this section. 
 	 */
 	columns?: {
-		numberOfColumns: null | number;
-		equalWidth: null | boolean; 
-		separator: null | boolean;
-		columns?: {columnWidth: Length | null, columnSpace?: Length | null}[] | null; 
+		/**
+		 * The number of columns in a section of text. If  this property is present it must 
+		 * be an integer greater than 0 and less than or equal to 45.
+		 */
+		numberOfColumns?: number;
+		equalWidth?: boolean;
+		separator?: boolean;
+		/**
+		 * The width of a column of text. If an array of columns is provided in the `columnDefs` 
+		 * property, then this value is ignored.
+		 */
+		columnSpace?: Length; 
+		/**
+		 * To create sections that use columns of different widths or uneven spacing, you can define
+		 * columns as an array of objects. This is _only_ used by Word if the `equalWidth` 
+		 * property is not true. 
+		 */
+		columnDefs?: {columnWidth?: Length, columnSpace?: Length }[]; 
 	}; 
 
 	/**
@@ -53,8 +66,7 @@ export type SectionProperties = {
 		header?: null | Length;
 		footer?: null | Length;
 		gutter?: null | Length;
-	};
-
+	}
 	/**
 	 * Specifies whether sections in the document shall have different headers and footers for even and odd pages.
 	 */
@@ -66,7 +78,7 @@ export function sectionPropertiesFromNode(node?: Node | null): SectionProperties
 		return {};
 	};
 
-	const data = evaluateXPathToMap<SectionProperties>(
+	return evaluateXPathToMap<SectionProperties>(
 		`map {
 			"headers": map {
 				"first": ./${QNS.w}headerReference[@${QNS.w}type = 'first']/@${QNS.r}id/string(),
@@ -80,12 +92,13 @@ export function sectionPropertiesFromNode(node?: Node | null): SectionProperties
 			},
 			"columns": map {
 				"numberOfColumns": ./${QNS.w}cols/@${QNS.w}num/number(), 
-				"separator": docxml:st-on-off(./${QNS.w}cols/@${QNS.w}sep),
 				"equalWidth": docxml:st-on-off(./${QNS.w}cols/@${QNS.w}equalwidth),
-				"columns": array{
+				"separator": docxml:st-on-off(./${QNS.w}cols/@${QNS.w}sep),
+				"columnSpace": docxml:length(./${QNS.w}cols/@${QNS.w}space, 'twip'),
+				"columnDefs": array{
 						./${QNS.w}cols/${QNS.w}col/map{ 
-						"columnWidth": if (@${QNS.w}w) then docxml:length(@${QNS.w}w, 'twip') else (), 
-						"columnSpace": if (@${QNS.w}space) then docxml:length(@${QNS.w}space, 'twip') else ()
+							"columnWidth": docxml:length(@${QNS.w}w, 'twip'), 
+							"columnSpace": docxml:length(@${QNS.w}space, 'twip')
 					}
 				}
 			},
@@ -105,16 +118,11 @@ export function sectionPropertiesFromNode(node?: Node | null): SectionProperties
 		}`,
 		node,
 	);
-
-	// console.log(data); 
-	return data;
 }
 
 export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 
-	// console.log(data.columns?.columns?.forEach((col) => { console.log(col.columnWidth)}))
-
-	const newNode = create(
+	return create(
 		`element ${QNS.w}sectPr {
 			if (exists($headers('first'))) then element ${QNS.w}headerReference {
 				attribute ${QNS.r}id { $headers('first') },
@@ -144,13 +152,13 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 				attribute ${QNS.w}sep { $columns('separator') },
 				attribute ${QNS.w}equalwidth { $columns('equalWidth') },
 				attribute ${QNS.w}num { $columns('numberOfColumns') },
- 
+				attribute ${QNS.w}space { round($columns('columnSpace')('twip')) },
  				if (docxml:st-on-off(string($columns('equalWidth')))) then ()
- 				else for $column in array:flatten($columns('columns'))
+ 				else for $column in array:flatten($columns('columnDefs'))
  					return element ${QNS.w}col {
- 						attribute ${QNS.w}w { round($column("columnWidth")("twip")) },
- 						if (not(exists($column("columnSpace")))) then ()
- 							else attribute ${QNS.w}space { round($column("columnSpace")("twip")) }
+ 						attribute ${QNS.w}w { round($column('columnWidth')('twip')) },
+ 						if (not(exists($column('columnSpace')))) then ()
+ 							else attribute ${QNS.w}space { round($column('columnSpace')('twip')) }
  					}
 			} else (), 
 			if (exists($pageWidth) or exists($pageHeight) or $pageOrientation) then element ${QNS.w}pgSz {
@@ -204,6 +212,4 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 			isTitlePage: data.isTitlePage || null,
 		}
 	);
-
-	return newNode; 
 }

--- a/src/properties/section-properties.ts
+++ b/src/properties/section-properties.ts
@@ -11,6 +11,17 @@ import { evaluateXPathToMap } from '../utilities/xquery.ts';
  */
 export type SectionProperties = {
 	/**
+	 * The column layout for a particular section of the document
+	 */
+	columns?: {
+		numberOfColumns: null | number;
+		equalWidth: null | boolean; 
+		separator: null | boolean;
+		columnSpacing?: null | Length;
+		columns?: {columnSize: Length, columnSpacing: Length | null }[]
+	}; 
+
+	/**
 	 * A reference to the header portion on every page in this section.
 	 */
 	headers?: null | string | { first?: string | null; even?: string | null; odd?: string | null };
@@ -54,41 +65,70 @@ export type SectionProperties = {
 export function sectionPropertiesFromNode(node?: Node | null): SectionProperties {
 	if (!node) {
 		return {};
-	}
+	}; 
 	const data = evaluateXPathToMap<SectionProperties>(
-		`map {
-			"headers": map {
-				"first": ./${QNS.w}headerReference[@${QNS.w}type = 'first']/@${QNS.r}id/string(),
-				"even": ./${QNS.w}headerReference[@${QNS.w}type = 'even']/@${QNS.r}id/string(),
-				"odd": ./${QNS.w}headerReference[@${QNS.w}type = 'default']/@${QNS.r}id/string()
-			},
-			"footers": map {
-				"first": ./${QNS.w}footerReference[@${QNS.w}type = 'first']/@${QNS.r}id/string(),
-				"even": ./${QNS.w}footerReference[@${QNS.w}type = 'even']/@${QNS.r}id/string(),
-				"odd": ./${QNS.w}footerReference[@${QNS.w}type = 'default']/@${QNS.r}id/string()
-			},
-			"pageWidth": docxml:length(${QNS.w}pgSz/@${QNS.w}w, 'twip'),
-			"pageHeight": docxml:length(${QNS.w}pgSz/@${QNS.w}h, 'twip'),
-			"pageOrientation": ./${QNS.w}pgSz/@${QNS.w}orient/string(),
-			"pageMargin": map {
-				"top": docxml:length(./${QNS.w}pgMar/@${QNS.w}top, 'twip'),
-				"right": docxml:length(./${QNS.w}pgMar/@${QNS.w}right, 'twip'),
-				"bottom": docxml:length(./${QNS.w}pgMar/@${QNS.w}bottom, 'twip'),
-				"left": docxml:length(./${QNS.w}pgMar/@${QNS.w}left, 'twip'),
-				"header": docxml:length(./${QNS.w}pgMar/@${QNS.w}header, 'twip'),
-				"footer": docxml:length(./${QNS.w}pgMar/@${QNS.w}footer, 'twip'),
-				"gutter": docxml:length(./${QNS.w}pgMar/@${QNS.w}gutter, 'twip')
-			},
-			"isTitlePage": exists(./${QNS.w}titlePg) and (not(./${QNS.w}titlePg/@${QNS.w}val) or docxml:st-on-off(./${QNS.w}titlePg/@${QNS.w}val))
-		}`,
+		`let $propsMap := map {
+				"headers": map {
+					"first": ./${QNS.w}headerReference[@${QNS.w}type = 'first']/@${QNS.r}id/string(),
+					"even": ./${QNS.w}headerReference[@${QNS.w}type = 'even']/@${QNS.r}id/string(),
+					"odd": ./${QNS.w}headerReference[@${QNS.w}type = 'default']/@${QNS.r}id/string()
+				},
+				"footers": map {
+					"first": ./${QNS.w}footerReference[@${QNS.w}type = 'first']/@${QNS.r}id/string(),
+					"even": ./${QNS.w}footerReference[@${QNS.w}type = 'even']/@${QNS.r}id/string(),
+					"odd": ./${QNS.w}footerReference[@${QNS.w}type = 'default']/@${QNS.r}id/string()
+				},
+				"columns": map {
+					"numberOfColumns": ./${QNS.w}cols/@${QNS.w}num/number(), 
+					"separator": docxml:st-on-off(./${QNS.w}cols/@${QNS.w}sep),
+					"equalWidth": docxml:st-on-off(./${QNS.w}cols/@${QNS.w}equalWidth)
+				},
+				"pageWidth": docxml:length(${QNS.w}pgSz/@${QNS.w}w, 'twip'),
+				"pageHeight": docxml:length(${QNS.w}pgSz/@${QNS.w}h, 'twip'),
+				"pageOrientation": ./${QNS.w}pgSz/@${QNS.w}orient/string(),
+				"pageMargin": map {
+					"top": docxml:length(./${QNS.w}pgMar/@${QNS.w}top, 'twip'),
+					"right": docxml:length(./${QNS.w}pgMar/@${QNS.w}right, 'twip'),
+					"bottom": docxml:length(./${QNS.w}pgMar/@${QNS.w}bottom, 'twip'),
+					"left": docxml:length(./${QNS.w}pgMar/@${QNS.w}left, 'twip'),
+					"header": docxml:length(./${QNS.w}pgMar/@${QNS.w}header, 'twip'),
+					"footer": docxml:length(./${QNS.w}pgMar/@${QNS.w}footer, 'twip'),
+					"gutter": docxml:length(./${QNS.w}pgMar/@${QNS.w}gutter, 'twip')
+				},
+				"isTitlePage": exists(./${QNS.w}titlePg) and (not(./${QNS.w}titlePg/@${QNS.w}val) or docxml:st-on-off(./${QNS.w}titlePg/@${QNS.w}val))
+		}
+		let $colSpacing := if (exists(./${QNS.w}cols/@${QNS.w}space)) then (docxml:length(./${QNS.w}cols/@${QNS.w}space, 'twip')) else ()
+		let $cols := ./${QNS.w}cols/${QNS.w}col
+		let $colMap := 
+			if (exists($cols))
+			then (
+				for-each(
+					$cols, 
+					function($c) {
+						map { 
+							"columnsSize": docxml:length($c/@${QNS.w}w, 'twip'), 
+							"columnSpacing": docxml:length($c/@${QNS.w}space, 'twip')
+						}
+					}
+				)
+			)
+			else()
+
+		return (
+			if (exists($colSpacing))
+			then (
+				map:put($propsMap('columns'), 'columnSpacing', $colSpacing)
+			)
+			else(),
+			map:put($propsMap('columns'), 'columns', $colMap)
+		)`,
 		node,
 	);
-
 	return data;
 }
 
 export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
-	return create(
+	const query = create(
 		`element ${QNS.w}sectPr {
 			if (exists($headers('first'))) then element ${QNS.w}headerReference {
 				attribute ${QNS.r}id { $headers('first') },
@@ -114,6 +154,24 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 				attribute ${QNS.r}id { $footers('odd') },
 				attribute ${QNS.w}type { 'default' }
 			} else (),
+			if (exists($columns)) then element ${QNS.w}cols {
+				attribute ${QNS.w}sep { $columns('separator') },
+				attribute ${QNS.w}equalWidth { $columns('equalWidth') },
+				attribute ${QNS.w}num { $columns('numberOfColumns') },
+				if (exists($columns('columnSpacing')))
+				then (
+					attribute ${QNS.w}columnSpacing { $columns('columnSpacing')}
+				)
+				else (),
+				if (exists($columns('columns')))
+				then (
+					element columns {
+						attribute ${QNS.w}w { round($columns('columns')('columnSize')('twip')) },
+						attribute ${QNS.w}space { round($columns('columns')('columnSpacing')('twip')) } 
+					}
+				)
+				else()
+			} else (), 
 			if (exists($pageWidth) or exists($pageHeight) or $pageOrientation) then element ${QNS.w}pgSz {
 				if (exists($pageWidth)) then attribute ${QNS.w}w {
 					round($pageWidth('twip'))
@@ -157,6 +215,13 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 				typeof data.footers === 'string'
 					? { first: data.footers, even: data.footers, odd: data.footers }
 					: data.footers || {},
+			columns: {
+				numberOfColumns: data.columns?.numberOfColumns,
+				separator: data.columns?.separator,
+				equalWidth: data.columns?.equalWidth,
+				columnSpacing: data.columns?.columnSpacing, 
+				columns: data.columns?.columns, 
+			},
 			pageWidth: data.pageWidth || null,
 			pageHeight: data.pageHeight || null,
 			pageMargin: data.pageMargin || null,
@@ -164,4 +229,5 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 			isTitlePage: data.isTitlePage || null,
 		},
 	);
+	return query; 
 }

--- a/src/properties/section-properties.ts
+++ b/src/properties/section-properties.ts
@@ -147,7 +147,7 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 				attribute ${QNS.w}num { $columns('numberOfColumns') },
 
 				if (docxml:st-on-off(string($columns('equalWidth')))) then ()
-				else for $column in $columns('columns')?*
+				else for $column in array:flatten($columns('columns'))
 					return element ${QNS.w}col {
 						attribute ${QNS.w}w { round($column("columnWidth")("twip")) },
 						if (not(exists($column("columnSpace")))) then ()

--- a/src/properties/section-properties.ts
+++ b/src/properties/section-properties.ts
@@ -145,7 +145,6 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 				attribute ${QNS.w}sep { $columns('separator') },
 				attribute ${QNS.w}equalwidth { $columns('equalWidth') },
 				attribute ${QNS.w}num { $columns('numberOfColumns') },
-
 				if (docxml:st-on-off(string($columns('equalWidth')))) then ()
 				else for $column in array:flatten($columns('columns'))
 					return element ${QNS.w}col {
@@ -153,6 +152,7 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 						if (not(exists($column("columnSpace")))) then ()
 							else attribute ${QNS.w}space { round($column("columnSpace")("twip")) }
 					}
+				)
 			} else (), 
 			if (exists($pageWidth) or exists($pageHeight) or $pageOrientation) then element ${QNS.w}pgSz {
 				if (exists($pageWidth)) then attribute ${QNS.w}w {

--- a/src/properties/section-properties.ts
+++ b/src/properties/section-properties.ts
@@ -83,7 +83,12 @@ export function sectionPropertiesFromNode(node?: Node | null): SectionProperties
 				"numberOfColumns": ./${QNS.w}cols/@${QNS.w}num/number(), 
 				"separator": docxml:st-on-off(./${QNS.w}cols/@${QNS.w}sep),
 				"equalWidth": docxml:st-on-off(./${QNS.w}cols/@${QNS.w}equalwidth),
-				"columns": array{}
+				"columns": array{
+						./${QNS.w}cols/${QNS.w}col/map{ 
+						"columnWidth": if (@${QNS.w}w) then docxml:length(@${QNS.w}w, 'twip') else (), 
+						"columnSpace": if (@${QNS.w}space) then docxml:length(@${QNS.w}space, 'twip') else ()
+					}
+				}
 			},
 			"pageWidth": docxml:length(${QNS.w}pgSz/@${QNS.w}w, 'twip'),
 			"pageHeight": docxml:length(${QNS.w}pgSz/@${QNS.w}h, 'twip'),
@@ -101,13 +106,6 @@ export function sectionPropertiesFromNode(node?: Node | null): SectionProperties
 		}`,
 		node,
 	);
-
-	evaluateXPathToArray(`array{./${QNS.w}cols/${QNS.w}col/map{ 
-		"columnWidth": if (@${QNS.w}w) then docxml:length(@${QNS.w}w, 'twip') else (), 
-		"columnSpace": if (@${QNS.w}space) then docxml:length(@${QNS.w}space, 'twip') else ()
-	}}`, node).forEach(({columnWidth, columnSpace}) => data.columns?.columns?.push(
-		{columnWidth: columnWidth || null, columnSpace: columnSpace || null}
-	)); 
 
 	// console.log(data); 
 	return data;
@@ -146,7 +144,15 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 			if (exists($columns) and $columns('numberOfColumns') > 0) then element ${QNS.w}cols {
 				attribute ${QNS.w}sep { $columns('separator') },
 				attribute ${QNS.w}equalwidth { $columns('equalWidth') },
-				attribute ${QNS.w}num { $columns('numberOfColumns') }
+				attribute ${QNS.w}num { $columns('numberOfColumns') },
+
+				if (docxml:st-on-off(string($columns('equalWidth')))) then ()
+				else for $column in $columns('columns')?*
+					return element ${QNS.w}col {
+						attribute ${QNS.w}w { round($column("columnWidth")("twip")) },
+						if (not(exists($column("columnSpace")))) then ()
+							else attribute ${QNS.w}space { round($column("columnSpace")("twip")) }
+					}
 			} else (), 
 			if (exists($pageWidth) or exists($pageHeight) or $pageOrientation) then element ${QNS.w}pgSz {
 				if (exists($pageWidth)) then attribute ${QNS.w}w {
@@ -191,36 +197,14 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 				typeof data.footers === 'string'
 					? { first: data.footers, even: data.footers, odd: data.footers }
 					: data.footers || {},
-			columns: {
-				numberOfColumns: data.columns?.numberOfColumns,
-				separator: data.columns?.separator,
-				equalWidth: data.columns?.equalWidth			},
+			columns: data.columns || {},
 			pageWidth: data.pageWidth || null,
 			pageHeight: data.pageHeight || null,
 			pageMargin: data.pageMargin || null,
 			pageOrientation: data.pageOrientation || null,
 			isTitlePage: data.isTitlePage || null,
 		}
-	); 
-	data.columns?.columns?.forEach((col) => { 
-		// console.log("COL"); 
-		if (col.columnWidth != undefined) { 
-			update(
-				newNode, 
-				`let $cols := ./${QNS.w}sectPr/${QNS.w}cols
-				return (
-					if (exists($cols))
-					then (
-						insert node element ${QNS.w}col {
-							attribute ${QNS.w}w { round(${col.columnWidth?.twip.toString() }) },
-							attribute ${QNS.w}space { round(${col.columnSpace?.twip.toString() }) }
-						} as last into $cols
-					) else () 
-				)
-				`
-			)
-		}
-	});
+	);
 
 	return newNode; 
 }

--- a/src/properties/section-properties.ts
+++ b/src/properties/section-properties.ts
@@ -144,14 +144,14 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 				attribute ${QNS.w}sep { $columns('separator') },
 				attribute ${QNS.w}equalwidth { $columns('equalWidth') },
 				attribute ${QNS.w}num { $columns('numberOfColumns') },
-				if (docxml:st-on-off(string($columns('equalWidth')))) then ()
-				else for $column in array:flatten($columns('columns'))
-					return element ${QNS.w}col {
-						attribute ${QNS.w}w { round($column("columnWidth")("twip")) },
-						if (not(exists($column("columnSpace")))) then ()
-							else attribute ${QNS.w}space { round($column("columnSpace")("twip")) }
-					}
-				)
+ 
+ 				if (docxml:st-on-off(string($columns('equalWidth')))) then ()
+ 				else for $column in array:flatten($columns('columns'))
+ 					return element ${QNS.w}col {
+ 						attribute ${QNS.w}w { round($column("columnWidth")("twip")) },
+ 						if (not(exists($column("columnSpace")))) then ()
+ 							else attribute ${QNS.w}space { round($column("columnSpace")("twip")) }
+ 					}
 			} else (), 
 			if (exists($pageWidth) or exists($pageHeight) or $pageOrientation) then element ${QNS.w}pgSz {
 				if (exists($pageWidth)) then attribute ${QNS.w}w {

--- a/src/properties/section-properties.ts
+++ b/src/properties/section-properties.ts
@@ -154,7 +154,13 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 				else (),
 				if (exists($columns('equalWidth'))) then attribute ${QNS.w}equalwidth {
 					$columns('equalWidth') 
-				} else (),
+				} else (
+					if (count($columns('columnDefs')) > 1)
+					then (
+						attribute ${QNS.w}equalwidth { false }
+					)
+					else () 
+				),
 				if (exists($columns('numberOfColumns'))) then attribute ${QNS.w}num {
 					$columns('numberOfColumns') 
 				} else (),

--- a/src/properties/section-properties.ts
+++ b/src/properties/section-properties.ts
@@ -30,7 +30,7 @@ export type SectionProperties = {
 		 * columns as an array of objects. This is _only_ used by Word if the `equalWidth` 
 		 * property is not true. 
 		 */
-		columnDefs?: {columnWidth?: Length, columnSpace?: Length }[]; 
+		columnDefs?: {columnWidth: Length, columnSpace?: Length }[]; 
 	}; 
 
 	/**
@@ -91,9 +91,9 @@ export function sectionPropertiesFromNode(node?: Node | null): SectionProperties
 				"odd": ./${QNS.w}footerReference[@${QNS.w}type = 'default']/@${QNS.r}id/string()
 			},
 			"columns": map {
-				"numberOfColumns": ./${QNS.w}cols/@${QNS.w}num/number(), 
+				"numberOfColumns": ./${QNS.w}cols/@${QNS.w}num/number(),
 				"equalWidth": docxml:st-on-off(./${QNS.w}cols/@${QNS.w}equalwidth),
-				"separator": docxml:st-on-off(./${QNS.w}cols/@${QNS.w}sep),
+				"separator": if (exists(./${QNS.w}cols/@${QNS.w}sep)) then docxml:st-on-off(./${QNS.w}cols/@${QNS.w}sep) else (),
 				"columnSpace": docxml:length(./${QNS.w}cols/@${QNS.w}space, 'twip'),
 				"columnDefs": array{
 						./${QNS.w}cols/${QNS.w}col/map{ 
@@ -148,11 +148,19 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 				attribute ${QNS.r}id { $footers('odd') },
 				attribute ${QNS.w}type { 'default' }
 			} else (),
-			if (exists($columns) and $columns('numberOfColumns') > 0) then element ${QNS.w}cols {
-				attribute ${QNS.w}sep { $columns('separator') },
-				attribute ${QNS.w}equalwidth { $columns('equalWidth') },
-				attribute ${QNS.w}num { $columns('numberOfColumns') },
-				attribute ${QNS.w}space { round($columns('columnSpace')('twip')) },
+			if (exists($columns)) then element ${QNS.w}cols {
+				if (exists($columns('separator'))) then attribute ${QNS.w}sep { 
+					$columns('separator') } 
+				else (),
+				if (exists($columns('equalWidth'))) then attribute ${QNS.w}equalwidth {
+					$columns('equalWidth') 
+				} else (),
+				if (exists($columns('numberOfColumns'))) then attribute ${QNS.w}num {
+					$columns('numberOfColumns') 
+				} else (),
+				if (exists($columns('columnSpace'))) then attribute ${QNS.w}space {
+					round($columns('columnSpace')('twip')) 
+				} else (),
  				if (docxml:st-on-off(string($columns('equalWidth')))) then ()
  				else for $column in array:flatten($columns('columnDefs'))
  					return element ${QNS.w}col {

--- a/src/properties/section-properties.ts
+++ b/src/properties/section-properties.ts
@@ -1,8 +1,7 @@
-import { create, update, serialize } from '../utilities/dom.ts';
+import { create } from '../utilities/dom.ts';
 import { Length } from '../utilities/length.ts';
 import { QNS } from '../utilities/namespaces.ts';
-import * as slimdom from 'https://esm.sh/slimdom@4.0.2?pin=v121'; 
-import { evaluateXPathToArray, evaluateXPathToFirstNode, evaluateXPathToMap } from '../utilities/xquery.ts';
+import { evaluateXPathToMap } from '../utilities/xquery.ts';
 
 /**
  * All the formatting options that can be given on a text run (inline text).

--- a/src/properties/section-properties.ts
+++ b/src/properties/section-properties.ts
@@ -1,7 +1,8 @@
-import { create } from '../utilities/dom.ts';
+import { create, update, serialize } from '../utilities/dom.ts';
 import { Length } from '../utilities/length.ts';
 import { QNS } from '../utilities/namespaces.ts';
-import { evaluateXPathToMap } from '../utilities/xquery.ts';
+import * as slimdom from 'https://esm.sh/slimdom@4.0.2?pin=v121'; 
+import { evaluateXPathToArray, evaluateXPathToFirstNode, evaluateXPathToMap } from '../utilities/xquery.ts';
 
 /**
  * All the formatting options that can be given on a text run (inline text).
@@ -17,8 +18,7 @@ export type SectionProperties = {
 		numberOfColumns: null | number;
 		equalWidth: null | boolean; 
 		separator: null | boolean;
-		columnSpacing?: null | Length;
-		columns?: {columnSize: Length, columnSpacing: Length | null }[]
+		columns?: {columnWidth: Length | null, columnSpace?: Length | null}[] | null; 
 	}; 
 
 	/**
@@ -65,70 +65,59 @@ export type SectionProperties = {
 export function sectionPropertiesFromNode(node?: Node | null): SectionProperties {
 	if (!node) {
 		return {};
-	}; 
-	const data = evaluateXPathToMap<SectionProperties>(
-		`let $propsMap := map {
-				"headers": map {
-					"first": ./${QNS.w}headerReference[@${QNS.w}type = 'first']/@${QNS.r}id/string(),
-					"even": ./${QNS.w}headerReference[@${QNS.w}type = 'even']/@${QNS.r}id/string(),
-					"odd": ./${QNS.w}headerReference[@${QNS.w}type = 'default']/@${QNS.r}id/string()
-				},
-				"footers": map {
-					"first": ./${QNS.w}footerReference[@${QNS.w}type = 'first']/@${QNS.r}id/string(),
-					"even": ./${QNS.w}footerReference[@${QNS.w}type = 'even']/@${QNS.r}id/string(),
-					"odd": ./${QNS.w}footerReference[@${QNS.w}type = 'default']/@${QNS.r}id/string()
-				},
-				"columns": map {
-					"numberOfColumns": ./${QNS.w}cols/@${QNS.w}num/number(), 
-					"separator": docxml:st-on-off(./${QNS.w}cols/@${QNS.w}sep),
-					"equalWidth": docxml:st-on-off(./${QNS.w}cols/@${QNS.w}equalWidth)
-				},
-				"pageWidth": docxml:length(${QNS.w}pgSz/@${QNS.w}w, 'twip'),
-				"pageHeight": docxml:length(${QNS.w}pgSz/@${QNS.w}h, 'twip'),
-				"pageOrientation": ./${QNS.w}pgSz/@${QNS.w}orient/string(),
-				"pageMargin": map {
-					"top": docxml:length(./${QNS.w}pgMar/@${QNS.w}top, 'twip'),
-					"right": docxml:length(./${QNS.w}pgMar/@${QNS.w}right, 'twip'),
-					"bottom": docxml:length(./${QNS.w}pgMar/@${QNS.w}bottom, 'twip'),
-					"left": docxml:length(./${QNS.w}pgMar/@${QNS.w}left, 'twip'),
-					"header": docxml:length(./${QNS.w}pgMar/@${QNS.w}header, 'twip'),
-					"footer": docxml:length(./${QNS.w}pgMar/@${QNS.w}footer, 'twip'),
-					"gutter": docxml:length(./${QNS.w}pgMar/@${QNS.w}gutter, 'twip')
-				},
-				"isTitlePage": exists(./${QNS.w}titlePg) and (not(./${QNS.w}titlePg/@${QNS.w}val) or docxml:st-on-off(./${QNS.w}titlePg/@${QNS.w}val))
-		}
-		let $colSpacing := if (exists(./${QNS.w}cols/@${QNS.w}space)) then (docxml:length(./${QNS.w}cols/@${QNS.w}space, 'twip')) else ()
-		let $cols := ./${QNS.w}cols/${QNS.w}col
-		let $colMap := 
-			if (exists($cols))
-			then (
-				for-each(
-					$cols, 
-					function($c) {
-						map { 
-							"columnsSize": docxml:length($c/@${QNS.w}w, 'twip'), 
-							"columnSpacing": docxml:length($c/@${QNS.w}space, 'twip')
-						}
-					}
-				)
-			)
-			else()
+	};
 
-		return (
-			if (exists($colSpacing))
-			then (
-				map:put($propsMap('columns'), 'columnSpacing', $colSpacing)
-			)
-			else(),
-			map:put($propsMap('columns'), 'columns', $colMap)
-		)`,
+	const data = evaluateXPathToMap<SectionProperties>(
+		`map {
+			"headers": map {
+				"first": ./${QNS.w}headerReference[@${QNS.w}type = 'first']/@${QNS.r}id/string(),
+				"even": ./${QNS.w}headerReference[@${QNS.w}type = 'even']/@${QNS.r}id/string(),
+				"odd": ./${QNS.w}headerReference[@${QNS.w}type = 'default']/@${QNS.r}id/string()
+			},
+			"footers": map {
+				"first": ./${QNS.w}footerReference[@${QNS.w}type = 'first']/@${QNS.r}id/string(),
+				"even": ./${QNS.w}footerReference[@${QNS.w}type = 'even']/@${QNS.r}id/string(),
+				"odd": ./${QNS.w}footerReference[@${QNS.w}type = 'default']/@${QNS.r}id/string()
+			},
+			"columns": map {
+				"numberOfColumns": ./${QNS.w}cols/@${QNS.w}num/number(), 
+				"separator": docxml:st-on-off(./${QNS.w}cols/@${QNS.w}sep),
+				"equalWidth": docxml:st-on-off(./${QNS.w}cols/@${QNS.w}equalwidth),
+				"columns": array{}
+			},
+			"pageWidth": docxml:length(${QNS.w}pgSz/@${QNS.w}w, 'twip'),
+			"pageHeight": docxml:length(${QNS.w}pgSz/@${QNS.w}h, 'twip'),
+			"pageOrientation": ./${QNS.w}pgSz/@${QNS.w}orient/string(),
+			"pageMargin": map {
+				"top": docxml:length(./${QNS.w}pgMar/@${QNS.w}top, 'twip'),
+				"right": docxml:length(./${QNS.w}pgMar/@${QNS.w}right, 'twip'),
+				"bottom": docxml:length(./${QNS.w}pgMar/@${QNS.w}bottom, 'twip'),
+				"left": docxml:length(./${QNS.w}pgMar/@${QNS.w}left, 'twip'),
+				"header": docxml:length(./${QNS.w}pgMar/@${QNS.w}header, 'twip'),
+				"footer": docxml:length(./${QNS.w}pgMar/@${QNS.w}footer, 'twip'),
+				"gutter": docxml:length(./${QNS.w}pgMar/@${QNS.w}gutter, 'twip')
+			},
+			"isTitlePage": exists(./${QNS.w}titlePg) and (not(./${QNS.w}titlePg/@${QNS.w}val) or docxml:st-on-off(./${QNS.w}titlePg/@${QNS.w}val))
+		}`,
 		node,
 	);
+
+	evaluateXPathToArray(`array{./${QNS.w}cols/${QNS.w}col/map{ 
+		"columnWidth": if (@${QNS.w}w) then docxml:length(@${QNS.w}w, 'twip') else (), 
+		"columnSpace": if (@${QNS.w}space) then docxml:length(@${QNS.w}space, 'twip') else ()
+	}}`, node).forEach(({columnWidth, columnSpace}) => data.columns?.columns?.push(
+		{columnWidth: columnWidth || null, columnSpace: columnSpace || null}
+	)); 
+
+	// console.log(data); 
 	return data;
 }
 
 export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
-	const query = create(
+
+	// console.log(data.columns?.columns?.forEach((col) => { console.log(col.columnWidth)}))
+
+	const newNode = create(
 		`element ${QNS.w}sectPr {
 			if (exists($headers('first'))) then element ${QNS.w}headerReference {
 				attribute ${QNS.r}id { $headers('first') },
@@ -154,23 +143,10 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 				attribute ${QNS.r}id { $footers('odd') },
 				attribute ${QNS.w}type { 'default' }
 			} else (),
-			if (exists($columns)) then element ${QNS.w}cols {
+			if (exists($columns) and $columns('numberOfColumns') > 0) then element ${QNS.w}cols {
 				attribute ${QNS.w}sep { $columns('separator') },
-				attribute ${QNS.w}equalWidth { $columns('equalWidth') },
-				attribute ${QNS.w}num { $columns('numberOfColumns') },
-				if (exists($columns('columnSpacing')))
-				then (
-					attribute ${QNS.w}columnSpacing { $columns('columnSpacing')}
-				)
-				else (),
-				if (exists($columns('columns')))
-				then (
-					element columns {
-						attribute ${QNS.w}w { round($columns('columns')('columnSize')('twip')) },
-						attribute ${QNS.w}space { round($columns('columns')('columnSpacing')('twip')) } 
-					}
-				)
-				else()
+				attribute ${QNS.w}equalwidth { $columns('equalWidth') },
+				attribute ${QNS.w}num { $columns('numberOfColumns') }
 			} else (), 
 			if (exists($pageWidth) or exists($pageHeight) or $pageOrientation) then element ${QNS.w}pgSz {
 				if (exists($pageWidth)) then attribute ${QNS.w}w {
@@ -218,16 +194,33 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 			columns: {
 				numberOfColumns: data.columns?.numberOfColumns,
 				separator: data.columns?.separator,
-				equalWidth: data.columns?.equalWidth,
-				columnSpacing: data.columns?.columnSpacing, 
-				columns: data.columns?.columns, 
-			},
+				equalWidth: data.columns?.equalWidth			},
 			pageWidth: data.pageWidth || null,
 			pageHeight: data.pageHeight || null,
 			pageMargin: data.pageMargin || null,
 			pageOrientation: data.pageOrientation || null,
 			isTitlePage: data.isTitlePage || null,
-		},
-	);
-	return query; 
+		}
+	); 
+	data.columns?.columns?.forEach((col) => { 
+		// console.log("COL"); 
+		if (col.columnWidth != undefined) { 
+			update(
+				newNode, 
+				`let $cols := ./${QNS.w}sectPr/${QNS.w}cols
+				return (
+					if (exists($cols))
+					then (
+						insert node element ${QNS.w}col {
+							attribute ${QNS.w}w { round(${col.columnWidth?.twip.toString() }) },
+							attribute ${QNS.w}space { round(${col.columnSpace?.twip.toString() }) }
+						} as last into $cols
+					) else () 
+				)
+				`
+			)
+		}
+	});
+
+	return newNode; 
 }

--- a/src/utilities/tests.ts
+++ b/src/utilities/tests.ts
@@ -126,6 +126,8 @@ export function createXmlRoundRobinTest<ObjectShape extends { [key: string]: unk
 	): void {
 		const value = p1[prop as keyof typeof p1];
 		const expectation = e1[prop as keyof typeof e1];
+		console.log("P1: ", p1); 
+		console.log("P2: ", p2); 
 		const reparsed = p2[prop as keyof typeof p2];
 
 		if (expectation && typeof expectation === 'object') {

--- a/src/utilities/tests.ts
+++ b/src/utilities/tests.ts
@@ -108,6 +108,40 @@ export async function expectDocumentToContain(
 	return expect(evaluateXPathToBoolean(test, dom.documentElement)).toBeTruthy();
 }
 
+
+function localAssert(
+	prop: string | number,
+	p1: Record<string, unknown> | Array<unknown>,
+	e1: Record<string, unknown> | Array<unknown>,
+	p2: Record<string, unknown> | Array<unknown>,
+): void {
+	const value = p1[prop as keyof typeof p1];
+	const expectation = e1[prop as keyof typeof e1];
+	const reparsed = p2[prop as keyof typeof p2];
+
+	if (expectation && typeof expectation === 'object') {
+		describe(`.${String(prop)}`, () => {
+			if(Array.isArray(expectation)) {
+				it('Has the expected length', () => {
+					expect(value).toHaveLength(expectation.length);
+				});
+			}
+			for (const p in expectation) {
+				localAssert(
+					p,
+					value as Record<string, unknown> | Array<unknown>,
+					expectation as Record<string, unknown> | Array<unknown>,
+					reparsed as Record<string, unknown> | Array<unknown>,
+				);
+			}
+		});
+	} else {
+		it(`.${String(prop)}`, () => {
+			expect(value).toBe(expectation);
+			expect(reparsed).toBe(expectation);
+		});
+	}
+}
 /**
  * Creates a small test suite to assert that an object can succesfully be parsed from XML, serialized
  * to XML again and then parses a 2nd time to the same object as before.
@@ -118,39 +152,6 @@ export function createXmlRoundRobinTest<ObjectShape extends { [key: string]: unk
 	fromNode: (n: Node | null) => ObjectShape,
 	toNode: (n: ObjectShape) => Node | null,
 ) {
-	function assert(
-		prop: string | number,
-		p1: Record<string, unknown> | Array<unknown>,
-		e1: Record<string, unknown> | Array<unknown>,
-		p2: Record<string, unknown> | Array<unknown>,
-	): void {
-		const value = p1[prop as keyof typeof p1];
-		const expectation = e1[prop as keyof typeof e1];
-		const reparsed = p2[prop as keyof typeof p2];
-
-		if (expectation && typeof expectation === 'object') {
-			describe(`.${String(prop)}`, () => {
-				if(Array.isArray(expectation)) {
-					it('Has the expected length', () => {
-						expect(value).toHaveLength(expectation.length);
-					});
-				}
-				for (const p in expectation) {
-					assert(
-						p,
-						value as Record<string, unknown> | Array<unknown>,
-						expectation as Record<string, unknown> | Array<unknown>,
-						reparsed as Record<string, unknown> | Array<unknown>,
-					);
-				}
-			});
-		} else {
-			it(`.${String(prop)}`, () => {
-				expect(value).toBe(expectation);
-				expect(reparsed).toBe(expectation);
-			});
-		}
-	}
 
 	return function test(xml: Node | string, parsedExpectation: ObjectShape) {
 		const dom = typeof xml === 'string' ? create(xml) : xml;
@@ -162,7 +163,29 @@ export function createXmlRoundRobinTest<ObjectShape extends { [key: string]: unk
 		}
 		const p2 = fromNode(serializedAgain);
 		for (const prop in parsedExpectation) {
-			assert(prop, p1, parsedExpectation, p2);
+			localAssert(prop, p1, parsedExpectation, p2);
 		}
 	};
+}
+
+export function createObjectRoundRobinTest<ObjectShape extends { [key:string]: unknown }> (
+	fromObject: (o: ObjectShape) => Node, 
+	toObject: (n: Node) => ObjectShape
+) {
+
+	return function test(testObject: ObjectShape, expectedXml: Node | string) {
+		const dom = typeof expectedXml === 'string' ? create(expectedXml) : expectedXml; 
+		const ob1 = toObject(dom); 
+		const convertedToDomAgain = fromObject(ob1);
+		if (typeof expectedXml !== 'string') { 
+			expectedXml.parentElement?.insertBefore(convertedToDomAgain, expectedXml);
+			expectedXml.parentElement?.removeChild(expectedXml);
+		}
+		const ob2 = toObject(convertedToDomAgain); 
+		
+		for (const prop in testObject) { 
+			localAssert(prop, ob1, testObject, ob2)
+		}
+	}
+
 }

--- a/src/utilities/tests.ts
+++ b/src/utilities/tests.ts
@@ -126,8 +126,6 @@ export function createXmlRoundRobinTest<ObjectShape extends { [key: string]: unk
 	): void {
 		const value = p1[prop as keyof typeof p1];
 		const expectation = e1[prop as keyof typeof e1];
-		console.log("P1: ", p1); 
-		console.log("P2: ", p2); 
 		const reparsed = p2[prop as keyof typeof p2];
 
 		if (expectation && typeof expectation === 'object') {


### PR DESCRIPTION
This PR adds basic support for the section properties necessary to create a document with columns. The `SectionProperties` type should now handle Word documents with `<w:cols>` elements, and any subsequent `<w:col>` elements for individually specified columns. 

