### PR TITLE
Insert leading space into footnote text

### DIFF
--- a/src/files/FootnotesXml.test.ts
+++ b/src/files/FootnotesXml.test.ts
@@ -97,7 +97,7 @@ describe('Footnotes', () => {
 						<w:footnoteRef/>
 					</w:r>
 					<w:r>
-						<w:t xml:space="preserve">Hello, this is a footnote.</w:t>
+						<w:t xml:space="preserve"> Hello, this is a footnote.</w:t>
 					</w:r>
 				</w:p>
 			</w:footnote>`;
@@ -144,7 +144,7 @@ describe('Footnotes', () => {
 						<w:footnoteRef/>
 					</w:r>
 					<w:r>
-						<w:t xml:space="preserve">Hello, this is a footnote 1.</w:t>
+						<w:t xml:space="preserve"> Hello, this is a footnote 1.</w:t>
 					</w:r>
 				</w:p>
 				<w:p>

--- a/src/files/FootnotesXml.ts
+++ b/src/files/FootnotesXml.ts
@@ -147,8 +147,10 @@ export class FootnotesXml extends XmlFileWithContentTypes {
 					if (firstNode instanceof Paragraph) {
 						// Check if the first child node is an image.
 						const [text] = firstNode.children;
-						const [image] = text ? text.children : [undefined];
-						if (image && image instanceof Image) {
+						const [imageOrText] = text
+							? text.children
+							: [undefined];
+						if (imageOrText && imageOrText instanceof Image) {
 							// The first child is an image. Insert the anchor in a new paragraph.
 							// This is what MSWord does by default.
 							footnote.content.unshift(
@@ -161,12 +163,10 @@ export class FootnotesXml extends XmlFileWithContentTypes {
 							);
 						} else {
 							if (
-								typeof firstNode.children[0].children[0] ===
-								'string'
+								imageOrText &&
+								typeof imageOrText === 'string'
 							) {
-								firstNode.children[0].children[0] = ' '.concat(
-									firstNode.children[0].children[0]
-								);
+								text.children[0] = ' '.concat(imageOrText);
 							}
 							firstNode.children.unshift(
 								new FootnoteAnchor({

--- a/src/files/FootnotesXml.ts
+++ b/src/files/FootnotesXml.ts
@@ -160,6 +160,14 @@ export class FootnotesXml extends XmlFileWithContentTypes {
 								)
 							);
 						} else {
+							if (
+								typeof firstNode.children[0].children[0] ===
+								'string'
+							) {
+								firstNode.children[0].children[0] = ' '.concat(
+									firstNode.children[0].children[0]
+								);
+							}
 							firstNode.children.unshift(
 								new FootnoteAnchor({
 									style: footnote.style,
@@ -205,7 +213,7 @@ export class FootnotesXml extends XmlFileWithContentTypes {
 							$footnote('content')
 						)
 						default return (
-							$footnote("content")
+							$footnote('content')
 						) 
 					return (
 						element w:footnote {  


### PR DESCRIPTION
Currently, when we generate a footnote, there is no space between a footnote's text and the reference number at the bottom of the page. 

This corrects the issue by inserting a space as the first character of the first paragraph of a footnote. It might be more idiomatic/elegant to add an empty `Text` object, but that changes the XML of the Word document in a way that Word does not, so I opted for this slightly clunkier fix. 