### PR TITLE
Fix path normalization.

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fontoxml/docxml",
-	"version": "5.15.11",
+	"version": "5.15.11-a",
 	"description": "A module for making .docx documents from scratch or from an existing .docx or .dotx template.",
 	"license": "MIT",
 	"homepage": "https://jsr.io/@fontoxml/docxml",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fontoxml/docxml",
-	"version": "5.15.11-b",
+	"version": "5.15.11",
 	"description": "A module for making .docx documents from scratch or from an existing .docx or .dotx template.",
 	"license": "MIT",
 	"homepage": "https://jsr.io/@fontoxml/docxml",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fontoxml/docxml",
-	"version": "5.15.11-a",
+	"version": "5.15.11-b",
 	"description": "A module for making .docx documents from scratch or from an existing .docx or .dotx template.",
 	"license": "MIT",
 	"homepage": "https://jsr.io/@fontoxml/docxml",

--- a/imports.json
+++ b/imports.json
@@ -1,10 +1,17 @@
 {
 	"imports": {
+		"@util-path": "./src/utilities/path.ts",
+
 		"slimdom": "npm:slimdom@4.3.5",
 		"fontoxpath": "npm:fontoxpath@3.33.0",
 		"std/expect": "jsr:@std/expect@1.0.15",
 		"std/fmt/colors": "jsr:@std/fmt@1.0.7/colors",
 		"std/path": "jsr:@std/path@1.0.9",
+		"std/path/posix/basename": "jsr:@std/path@1.0.9/posix/basename",
+		"std/path/posix/dirname": "jsr:@std/path@1.0.9/posix/dirname",
+		"std/path/posix/join": "jsr:@std/path@1.0.9/posix/join",
+		"std/path/posix/relative": "jsr:@std/path@1.0.9/posix/relative",
+		"std/path/posix/resolve": "jsr:@std/path@1.0.9/posix/resolve",
 		"std/testing/bdd": "jsr:@std/testing@1.0.9/bdd",
 		"std/fmt": "jsr:@std/fmt@1.0.7",
 		"jszip": "npm:jszip@3.10.1",

--- a/src/classes/Archive.ts
+++ b/src/classes/Archive.ts
@@ -1,5 +1,4 @@
 import JSZip from 'jszip';
-import { normalize } from 'std/path';
 
 import { parse, serialize } from '../utilities/dom.ts';
 
@@ -22,36 +21,31 @@ export class Archive {
 	}
 
 	hasFile(location: string): boolean {
-		const normalizedLocation = normalize(location);
-		return normalizedLocation in this.#files;
+		return location in this.#files;
 	}
 
 	readText(location: string): Promise<string> {
-		const normalizedLocation = normalize(location);
-		const data = this.#files[normalizedLocation];
+		const data = this.#files[location];
 		if (!data) {
-			throw new Error(`File not found: ${normalizedLocation}`);
+			throw new Error(`File not found: ${location}`);
 		}
 		return Promise.resolve(new TextDecoder().decode(data));
 	}
 
 	async readXml(location: string): Promise<Document> {
-		const normalizedLocation = normalize(location);
-		return parse(await this.readText(normalizedLocation));
+		return parse(await this.readText(location));
 	}
 
 	readBinary(location: string): Promise<Uint8Array> {
-		const normalizedLocation = normalize(location);
-		const data = this.#files[normalizedLocation];
+		const data = this.#files[location];
 		if (!data) {
-			throw new Error(`File not found: ${normalizedLocation}`);
+			throw new Error(`File not found: ${location}`);
 		}
 		return Promise.resolve(data);
 	}
 
 	addTextFile(location: string, contents: string): this {
-		const normalizedLocation = normalize(location);
-		this.#files[normalizedLocation] = new TextEncoder().encode(contents);
+		this.#files[location] = new TextEncoder().encode(contents);
 		return this;
 	}
 
@@ -69,10 +63,7 @@ export class Archive {
 	}
 
 	addBinaryFile(location: string, promised: Promise<Uint8Array>): this {
-		this.#promises.push({
-			location: normalize(location),
-			promise: promised,
-		});
+		this.#promises.push({ location, promise: promised });
 		return this;
 	}
 
@@ -95,9 +86,8 @@ export class Archive {
 
 		zip.forEach((path, file) => {
 			if (!file.dir) {
-				const normalizedPath = normalize(path);
 				const p = file.async('uint8array').then((contents) => {
-					files[normalizedPath] = contents;
+					files[path] = contents;
 				});
 				promises.push(p);
 			}
@@ -108,13 +98,11 @@ export class Archive {
 	}
 
 	static async fromFile(location: string): Promise<Archive> {
-		const normalizedLocation = normalize(location);
-		const data = await Deno.readFile(normalizedLocation);
+		const data = await Deno.readFile(location);
 		return Archive.fromUInt8Array(data);
 	}
 
 	async toFile(location: string): Promise<void> {
-		const normalizedLocation = normalize(location);
-		await Deno.writeFile(normalizedLocation, await this.asUint8Array());
+		await Deno.writeFile(location, await this.asUint8Array());
 	}
 }

--- a/src/files/CommentsXml.ts
+++ b/src/files/CommentsXml.ts
@@ -1,4 +1,4 @@
-import * as path from 'std/path';
+import { dirname, basename } from '@util-path';
 
 import type { ContentTypesXml } from '../../mod.ts';
 import type { Archive } from '../classes/Archive.ts';
@@ -120,7 +120,7 @@ export class CommentsXml extends XmlFileWithContentTypes {
 	): Promise<CommentsXml> {
 		const dom = await archive.readXml(location);
 
-		const relsLocation = `${path.dirname(location)}/_rels/${path.basename(
+		const relsLocation = `${dirname(location)}/_rels/${basename(
 			location
 		)}.rels`;
 		const relationships = archive.hasFile(relsLocation)

--- a/src/files/DocumentXml.ts
+++ b/src/files/DocumentXml.ts
@@ -1,4 +1,4 @@
-import * as path from 'std/path';
+import { basename, dirname } from '@util-path';
 
 import type { ContentTypesXml } from '../../mod.ts';
 import type { Archive } from '../classes/Archive.ts';
@@ -45,7 +45,7 @@ export class DocumentXml extends XmlFileWithContentTypes {
 	public constructor(
 		location: string,
 		relationships: RelationshipsXml = new RelationshipsXml(
-			`${path.dirname(location)}/_rels/${path.basename(location)}.rels`
+			`${dirname(location)}/_rels/${basename(location)}.rels`
 		)
 	) {
 		super(location);
@@ -208,9 +208,7 @@ export class DocumentXml extends XmlFileWithContentTypes {
 			const inst = new HeaderXml(
 				location,
 				new RelationshipsXml(
-					`${path.dirname(location)}/_rels/${path.basename(
-						location
-					)}.rels`
+					`${dirname(location)}/_rels/${basename(location)}.rels`
 				)
 			);
 			inst.set(root);
@@ -233,9 +231,7 @@ export class DocumentXml extends XmlFileWithContentTypes {
 			const inst = new FooterXml(
 				location,
 				new RelationshipsXml(
-					`${path.dirname(location)}/_rels/${path.basename(
-						location
-					)}.rels`
+					`${dirname(location)}/_rels/${basename(location)}.rels`
 				)
 			);
 			inst.set(root);
@@ -261,7 +257,7 @@ export class DocumentXml extends XmlFileWithContentTypes {
 		const relationships = await RelationshipsXml.fromArchive(
 			archive,
 			contentTypes,
-			`${path.dirname(location)}/_rels/${path.basename(location)}.rels`
+			`${dirname(location)}/_rels/${basename(location)}.rels`
 		);
 		const doc = new DocumentXml(location, relationships);
 		const dom = await archive.readXml(location);

--- a/src/files/FootnotesXml.ts
+++ b/src/files/FootnotesXml.ts
@@ -1,4 +1,5 @@
-import * as path from 'std/path';
+import { basename, dirname } from '@util-path';
+
 import type { Archive } from '../classes/Archive.ts';
 import { NumberMap } from '../classes/NumberMap.ts';
 import { XmlFileWithContentTypes } from '../classes/XmlFile.ts';
@@ -44,7 +45,7 @@ export class FootnotesXml extends XmlFileWithContentTypes {
 	public constructor(
 		location: string,
 		relationships: RelationshipsXml = new RelationshipsXml(
-			`${path.dirname(location)}/_rels/${path.basename(location)}.rels`
+			`${dirname(location)}/_rels/${basename(location)}.rels`
 		)
 	) {
 		super(location);
@@ -242,9 +243,7 @@ export class FootnotesXml extends XmlFileWithContentTypes {
 		contentTypes: ContentTypesXml,
 		location: string
 	): Promise<FootnotesXml> {
-		const relsLocation = `${path.dirname(location)}/_rels/${path.basename(
-			location
-		)}`;
+		const relsLocation = `${dirname(location)}/_rels/${basename(location)}`;
 		const inst = new this(location);
 		if (archive.hasFile(relsLocation)) {
 			const relsDom = await archive.readXml(location);

--- a/src/files/HeaderFooterXml.ts
+++ b/src/files/HeaderFooterXml.ts
@@ -1,4 +1,4 @@
-import * as path from 'std/path';
+import { basename, dirname } from '@util-path';
 
 import type { ContentTypesXml } from '../../mod.ts';
 import type { Archive } from '../classes/Archive.ts';
@@ -129,7 +129,7 @@ export class HeaderXml extends HeaderFooterAbstractionXml<
 		location: string
 	): Promise<HeaderXml> {
 		const dom = await archive.readXml(location);
-		const relsLocation = `${path.dirname(location)}/_rels/${path.basename(
+		const relsLocation = `${dirname(location)}/_rels/${basename(
 			location
 		)}.rels`;
 		const relationships = archive.hasFile(relsLocation)
@@ -183,7 +183,7 @@ export class FooterXml extends HeaderFooterAbstractionXml<HeaderFooterChild> {
 		location: string
 	): Promise<FooterXml> {
 		const dom = await archive.readXml(location);
-		const relsLocation = `${path.dirname(location)}/_rels/${path.basename(
+		const relsLocation = `${dirname(location)}/_rels/${basename(
 			location
 		)}.rels`;
 		const relationships = archive.hasFile(relsLocation)

--- a/src/files/RelationshipsXml.ts
+++ b/src/files/RelationshipsXml.ts
@@ -1,4 +1,5 @@
-import * as path from 'std/path';
+import { dirname, join, relative } from '@util-path';
+
 import type { ContentTypesXml } from '../../mod.ts';
 import type { Archive } from '../classes/Archive.ts';
 import { BinaryFile } from '../classes/BinaryFile.ts';
@@ -160,10 +161,8 @@ export class RelationshipsXml extends XmlFileWithContentTypes {
 							...meta,
 							target: meta.isExternal
 								? meta.target
-								: path.relative(
-										path.dirname(
-											path.dirname(this.location)
-										),
+								: relative(
+										dirname(dirname(this.location)),
 										meta.target
 								  ),
 						}
@@ -218,7 +217,7 @@ export class RelationshipsXml extends XmlFileWithContentTypes {
 			...meta,
 			target: meta.isExternal
 				? meta.target
-				: path.join(path.dirname(location), '..', meta.target),
+				: join(dirname(location), '..', meta.target),
 			isBinary: meta.type === RelationshipType.image,
 		})) as RelationshipMeta[];
 

--- a/src/files/SettingsXml.ts
+++ b/src/files/SettingsXml.ts
@@ -1,4 +1,4 @@
-import * as path from 'std/path';
+import { basename, dirname } from '@util-path';
 
 import type { ContentTypesXml, Length } from '../../mod.ts';
 import type { Archive } from '../classes/Archive.ts';
@@ -107,7 +107,7 @@ export class SettingsXml extends XmlFileWithContentTypes {
 	public constructor(
 		location: string,
 		relationships: RelationshipsXml = new RelationshipsXml(
-			`${path.dirname(location)}/_rels/${path.basename(location)}.rels`
+			`${dirname(location)}/_rels/${basename(location)}.rels`
 		),
 		settings: Partial<SettingsI> = {}
 	) {
@@ -237,9 +237,9 @@ export class SettingsXml extends XmlFileWithContentTypes {
 	): Promise<SettingsXml> {
 		let relationships;
 
-		const relationshipsLocation = `${path.dirname(
+		const relationshipsLocation = `${dirname(location)}/_rels/${basename(
 			location
-		)}/_rels/${path.basename(location)}.rels`;
+		)}.rels`;
 		try {
 			relationships = await RelationshipsXml.fromArchive(
 				archive,

--- a/src/utilities/path.ts
+++ b/src/utilities/path.ts
@@ -1,0 +1,5 @@
+export { dirname } from 'std/path/posix/dirname';
+export { join } from 'std/path/posix/join';
+export { relative } from 'std/path/posix/relative';
+export { basename } from 'std/path/posix/basename';
+export { resolve } from 'std/path/posix/resolve';

--- a/src/utilities/tests.ts
+++ b/src/utilities/tests.ts
@@ -2,8 +2,9 @@
  * @file
  * All the helper functions for test purposes only.
  */
-import * as path from 'std/path'; 
-import { expect} from 'std/expect'; 
+import { resolve } from '@util-path';
+
+import { expect } from 'std/expect';
 import { describe, it } from 'std/testing/bdd';
 
 import { Archive } from '../classes/Archive.ts';
@@ -18,12 +19,12 @@ import { evaluateXPathToBoolean } from './xquery.ts';
 const ZIPS = new Map<string, Archive>();
 
 export function file(absolutePathFromProjectDir: string) {
-	return path.resolve(
+	return resolve(
 		new URL(import.meta.url).pathname,
 		'..',
 		'..',
 		'..',
-		absolutePathFromProjectDir,
+		absolutePathFromProjectDir
 	);
 }
 
@@ -32,7 +33,10 @@ export function file(absolutePathFromProjectDir: string) {
  */
 export async function archive(archiveLocation: string): Promise<Archive> {
 	if (!ZIPS.has(archiveLocation)) {
-		ZIPS.set(archiveLocation, await Archive.fromFile(file(archiveLocation)));
+		ZIPS.set(
+			archiveLocation,
+			await Archive.fromFile(file(archiveLocation))
+		);
 	}
 	const zip = ZIPS.get(archiveLocation);
 	if (!zip) {
@@ -45,7 +49,10 @@ export async function archive(archiveLocation: string): Promise<Archive> {
  * Get the text contents of a file in a ZIP archive. The archive location is absolute from the
  * project directory. The file location is absolute from the ZIP root.
  */
-export async function archivedText(archiveLocation: string, fileLocation: string) {
+export async function archivedText(
+	archiveLocation: string,
+	fileLocation: string
+) {
 	const zip = await archive(archiveLocation);
 	return zip.readText(fileLocation);
 }
@@ -54,7 +61,10 @@ export async function archivedText(archiveLocation: string, fileLocation: string
  * Get the DOM of an XML file in a ZIP archive. The archive location is absolute from the
  * project directory. The file location is absolute from the ZIP root.
  */
-export async function archivedXml(archiveLocation: string, fileLocation: string) {
+export async function archivedXml(
+	archiveLocation: string,
+	fileLocation: string
+) {
 	const zip = await archive(archiveLocation);
 	return zip.readXml(fileLocation);
 }
@@ -66,11 +76,17 @@ export async function archivedXml(archiveLocation: string, fileLocation: string)
 export async function archivedFile(
 	archiveLocation: string,
 	type: RelationshipType,
-	fileLocation: string,
+	fileLocation: string
 ) {
 	const zip = await archive(archiveLocation);
-	const contentTypes = await ContentTypesXml.fromArchive(zip, FileLocation.contentTypes);
-	return castRelationshipToClass(zip, contentTypes, { type, target: fileLocation });
+	const contentTypes = await ContentTypesXml.fromArchive(
+		zip,
+		FileLocation.contentTypes
+	);
+	return castRelationshipToClass(zip, contentTypes, {
+		type,
+		target: fileLocation,
+	});
 }
 
 /**
@@ -82,38 +98,43 @@ export async function archivedFile(
 export async function expectDocxToContain(
 	bundle: Docx,
 	relationshipType: RelationshipType,
-	test: string,
+	test: string
 ) {
-	const document = bundle.relationships.findInstance((meta) => meta.type === relationshipType);
-	if (!document) {
-		throw new Error('$$$ Unknown relationship ' + relationshipType);
-	}
-	const dom = await (document as XmlFile).$$$toNode();
-
-	return expect(evaluateXPathToBoolean(test, dom.documentElement)).toBeTruthy();
-}
-export async function expectDocumentToContain(
-	bundle: Docx,
-	relationshipType: RelationshipType,
-	test: string,
-) {
-	const document = bundle.document.relationships.findInstance(
-		(meta) => meta.type === relationshipType,
+	const document = bundle.relationships.findInstance(
+		(meta) => meta.type === relationshipType
 	);
 	if (!document) {
 		throw new Error('$$$ Unknown relationship ' + relationshipType);
 	}
 	const dom = await (document as XmlFile).$$$toNode();
 
-	return expect(evaluateXPathToBoolean(test, dom.documentElement)).toBeTruthy();
+	return expect(
+		evaluateXPathToBoolean(test, dom.documentElement)
+	).toBeTruthy();
 }
+export async function expectDocumentToContain(
+	bundle: Docx,
+	relationshipType: RelationshipType,
+	test: string
+) {
+	const document = bundle.document.relationships.findInstance(
+		(meta) => meta.type === relationshipType
+	);
+	if (!document) {
+		throw new Error('$$$ Unknown relationship ' + relationshipType);
+	}
+	const dom = await (document as XmlFile).$$$toNode();
 
+	return expect(
+		evaluateXPathToBoolean(test, dom.documentElement)
+	).toBeTruthy();
+}
 
 function localAssert(
 	prop: string | number,
 	p1: Record<string, unknown> | Array<unknown>,
 	e1: Record<string, unknown> | Array<unknown>,
-	p2: Record<string, unknown> | Array<unknown>,
+	p2: Record<string, unknown> | Array<unknown>
 ): void {
 	const value = p1[prop as keyof typeof p1];
 	const expectation = e1[prop as keyof typeof e1];
@@ -121,7 +142,7 @@ function localAssert(
 
 	if (expectation && typeof expectation === 'object') {
 		describe(`.${String(prop)}`, () => {
-			if(Array.isArray(expectation)) {
+			if (Array.isArray(expectation)) {
 				it('Has the expected length', () => {
 					expect(value).toHaveLength(expectation.length);
 				});
@@ -131,7 +152,7 @@ function localAssert(
 					p,
 					value as Record<string, unknown> | Array<unknown>,
 					expectation as Record<string, unknown> | Array<unknown>,
-					reparsed as Record<string, unknown> | Array<unknown>,
+					reparsed as Record<string, unknown> | Array<unknown>
 				);
 			}
 		});
@@ -148,11 +169,12 @@ function localAssert(
  *
  * Succeeding this test means the two functions convert back-and-forth without loss of information.
  */
-export function createXmlRoundRobinTest<ObjectShape extends { [key: string]: unknown }>(
+export function createXmlRoundRobinTest<
+	ObjectShape extends { [key: string]: unknown }
+>(
 	fromNode: (n: Node | null) => ObjectShape,
-	toNode: (n: ObjectShape) => Node | null,
+	toNode: (n: ObjectShape) => Node | null
 ) {
-
 	return function test(xml: Node | string, parsedExpectation: ObjectShape) {
 		const dom = typeof xml === 'string' ? create(xml) : xml;
 		const p1 = fromNode(dom);
@@ -168,24 +190,25 @@ export function createXmlRoundRobinTest<ObjectShape extends { [key: string]: unk
 	};
 }
 
-export function createObjectRoundRobinTest<ObjectShape extends { [key:string]: unknown }> (
-	fromObject: (o: ObjectShape) => Node, 
-	toObject: (n: Node) => ObjectShape
-) {
-
+export function createObjectRoundRobinTest<
+	ObjectShape extends { [key: string]: unknown }
+>(fromObject: (o: ObjectShape) => Node, toObject: (n: Node) => ObjectShape) {
 	return function test(testObject: ObjectShape, expectedXml: Node | string) {
-		const dom = typeof expectedXml === 'string' ? create(expectedXml) : expectedXml; 
-		const ob1 = toObject(dom); 
+		const dom =
+			typeof expectedXml === 'string' ? create(expectedXml) : expectedXml;
+		const ob1 = toObject(dom);
 		const convertedToDomAgain = fromObject(ob1);
-		if (typeof expectedXml !== 'string') { 
-			expectedXml.parentElement?.insertBefore(convertedToDomAgain, expectedXml);
+		if (typeof expectedXml !== 'string') {
+			expectedXml.parentElement?.insertBefore(
+				convertedToDomAgain,
+				expectedXml
+			);
 			expectedXml.parentElement?.removeChild(expectedXml);
 		}
-		const ob2 = toObject(convertedToDomAgain); 
-		
-		for (const prop in testObject) { 
-			localAssert(prop, ob1, testObject, ob2)
-		}
-	}
+		const ob2 = toObject(convertedToDomAgain);
 
+		for (const prop in testObject) {
+			localAssert(prop, ob1, testObject, ob2);
+		}
+	};
 }


### PR DESCRIPTION
This PR reverts https://github.com/FontoXML/docxml/commit/d4c70545f88e653184e57fd0a981fcb2d812765f, which mistakenly "fixed" the normalization of paths.

The correct fix:
- All paths are now POSIX paths. We were currently mixing Windows and POSIX paths.