### PR TITLE
Add the `moveRange` element to support track-changes moves

### DIFF
--- a/examples/track-changes/track-changes-move.tsx
+++ b/examples/track-changes/track-changes-move.tsx
@@ -49,6 +49,14 @@ const moveToParagraph = new Paragraph(
 	})
 );
 
+const betweenParagraph = new Paragraph(
+	{},
+	new Text(
+		{},
+		'This will go before a completely move paragraph, but will show up as after it. '
+	)
+);
+
 const moveFromParagraph = new Paragraph(
 	{
 		pilcrow: {
@@ -133,6 +141,7 @@ const moveTextParagraph = new Paragraph(
 const section = new Section(
 	{},
 	moveToParagraph,
+	betweenParagraph,
 	moveFromParagraph,
 	moveTextParagraph
 );

--- a/examples/track-changes/track-changes-move.tsx
+++ b/examples/track-changes/track-changes-move.tsx
@@ -1,0 +1,105 @@
+import Docx, {
+	Move,
+	MoveRangeEnd,
+	MoveRangeStart,
+	Paragraph,
+	Section,
+	Text,
+} from '../../mod.ts';
+
+// Create a new Word document with track changes enabled.
+const docxFile = Docx.fromNothing().withSettings({
+	isTrackChangesEnabled: true,
+});
+
+const date = new Date();
+
+// Create an instance of a paragraph where the entire paragraph has been moved. This type of move
+// has no range associated with it. It is assumed the parent paragraph is the extent of the range.
+const moveToParagraph = new Paragraph(
+	{
+		pilcrow: {
+			move: {
+				id: 1,
+				date: date,
+				type: 'to',
+				author: 'Gabe',
+			},
+		},
+	},
+	new Text({}, 'This is an example of some moved text.')
+);
+
+const moveFromParagraph = new Paragraph(
+	{
+		pilcrow: {
+			move: {
+				id: 1,
+				date: date,
+				type: 'from',
+				author: 'Gabe',
+			},
+		},
+	},
+	new Text({}, 'This is an example of some moved text.')
+);
+
+// Create an instance where text within a paragraph has been been moved. We will need to create a MoveRangeStart
+// and MoveRangeEnd and Move for each piece of text that is moved.
+const moveTextParagraph = new Paragraph(
+	{},
+	new MoveRangeStart({
+		type: 'to',
+		name: 'move_0',
+		author: 'Gabe',
+		date: date,
+		id: 2,
+	}),
+	new Move(
+		{
+			type: 'to',
+			author: 'Gabe',
+			date: date,
+			id: 2,
+		},
+		new Text({}, 'And this is some text that will move to be first.')
+	),
+	new MoveRangeEnd({
+		type: 'to',
+		id: 2,
+	}),
+	new Text({}, ' It will come from the middle of the text. '),
+	new MoveRangeStart({
+		type: 'from',
+		name: 'move_0',
+		author: 'Gabe',
+		date: date,
+		id: 3,
+	}),
+	new Move(
+		{
+			type: 'from',
+			author: 'Gabe',
+			date: date,
+			id: 3,
+		},
+		new Text({}, 'And this is some text that will move to be first.')
+	),
+	new MoveRangeEnd({
+		type: 'from',
+		id: 3,
+	})
+);
+
+// Add all three of the paragraphs we created to our document.
+const section = new Section(
+	{},
+	moveToParagraph,
+	moveFromParagraph,
+	moveTextParagraph
+);
+
+docxFile.document.set(section);
+
+// Write to a file.
+docxFile.toFile('track-changes-move.docx');

--- a/examples/track-changes/track-changes-move.tsx
+++ b/examples/track-changes/track-changes-move.tsx
@@ -27,7 +27,26 @@ const moveToParagraph = new Paragraph(
 			},
 		},
 	},
-	new Text({}, 'This is an example of some moved text.')
+	new MoveRangeStart({
+		type: 'to',
+		name: 'move_0',
+		author: 'Gabe',
+		date: date,
+		id: 3,
+	}),
+	new Move(
+		{
+			type: 'to',
+			id: 4,
+			date: date,
+			author: 'Gabe',
+		},
+		new Text({}, 'This is an example of some moved text.')
+	),
+	new MoveRangeEnd({
+		type: 'to',
+		id: 4,
+	})
 );
 
 const moveFromParagraph = new Paragraph(
@@ -41,7 +60,26 @@ const moveFromParagraph = new Paragraph(
 			},
 		},
 	},
-	new Text({}, 'This is an example of some moved text.')
+	new MoveRangeStart({
+		type: 'from',
+		name: 'move_0',
+		author: 'Gabe',
+		date: date,
+		id: 3,
+	}),
+	new Move(
+		{
+			type: 'from',
+			id: 4,
+			date: date,
+			author: 'Gabe',
+		},
+		new Text({}, 'This is an example of some moved text.')
+	),
+	new MoveRangeEnd({
+		type: 'from',
+		id: 4,
+	})
 );
 
 // Create an instance where text within a paragraph has been been moved. We will need to create a MoveRangeStart

--- a/mod.ts
+++ b/mod.ts
@@ -78,6 +78,16 @@ export {
 } from './src/components/Image.ts';
 export { Move, type MoveChild, type MoveProps } from './src/components/Move.ts';
 export {
+	MoveRangeEnd,
+	type MoveRangeEndChild,
+	type MoveRangeEndProps,
+} from './src/components/MoveRangeEnd.ts';
+export {
+	MoveRangeStart,
+	type MoveRangeStartChild,
+	type MoveRangeStartProps,
+} from './src/components/MoveRangeStart.ts';
+export {
 	NonBreakingHyphen,
 	type NonBreakingHyphenChild,
 	type NonBreakingHyphenProps,

--- a/src/components/Move.ts
+++ b/src/components/Move.ts
@@ -22,6 +22,8 @@ import {
 import { create } from '../utilities/dom.ts';
 import { QNS } from '../utilities/namespaces.ts';
 import { evaluateXPathToMap } from '../utilities/xquery.ts';
+import type { MoveRangeEnd } from './MoveRangeEnd.ts';
+import type { MoveRangeStart } from './MoveRangeStart.ts';
 import './Text.ts';
 
 /**
@@ -35,7 +37,9 @@ export type MoveChild =
 	| TextAddition
 	| TextDeletion
 	| Text
-	| Move;
+	| Move
+	| MoveRangeStart
+	| MoveRangeEnd;
 
 /**
  * A type describing the props accepted by {@link Move}.

--- a/src/components/MoveRangeEnd.test.ts
+++ b/src/components/MoveRangeEnd.test.ts
@@ -1,0 +1,52 @@
+import { expect } from 'std/expect';
+import { describe, it } from 'std/testing/bdd';
+
+import { create, serialize } from '../utilities/dom.ts';
+import { NamespaceUri } from '../utilities/namespaces.ts';
+import { MoveRangeEnd } from './MoveRangeEnd.ts';
+
+describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
+	const moveToRangeEnd = MoveRangeEnd.fromNode(
+		create(`<w:moveToRangeEnd xmlns:w="${NamespaceUri.w}" w:id="0" />`)
+	);
+
+	const moveFromRangeEnd = MoveRangeEnd.fromNode(
+		create(`<w:moveFromRangeEnd xmlns:w="${NamespaceUri.w}" w:id="1" />`)
+	);
+	it('Create MoveToRangeEnd from node', () => {
+		expect(moveToRangeEnd.props.id).toBe(0);
+		expect(moveToRangeEnd.props.type).toBe('to');
+	});
+
+	it('Create MoveFromRangeEnd from node', () => {
+		expect(moveFromRangeEnd.props.id).toBe(1);
+		expect(moveFromRangeEnd.props.type).toBe('from');
+	});
+
+	it('Create MoveToRangeEnd node from MoveRangeEnd object', () => {
+		const toRangeObject = new MoveRangeEnd({
+			id: 2,
+			type: 'to',
+		});
+
+		expect(serialize(toRangeObject.toNode())).toBe(
+			serialize(
+				create(
+					`<moveToRangeEnd xmlns="${NamespaceUri.w}" xmlns:ns1="${NamespaceUri.w}" ns1:id="2" />`
+				)
+			)
+		);
+
+		const fromRangeObject = new MoveRangeEnd({
+			id: 3,
+			type: 'from',
+		});
+		expect(serialize(fromRangeObject.toNode())).toBe(
+			serialize(
+				create(
+					`<moveFromRangeEnd xmlns="${NamespaceUri.w}" xmlns:ns1="${NamespaceUri.w}" ns1:id="3" />`
+				)
+			)
+		);
+	});
+});

--- a/src/components/MoveRangeEnd.ts
+++ b/src/components/MoveRangeEnd.ts
@@ -1,0 +1,85 @@
+// Import without assignment ensures Deno does not tree-shake this component. To avoid circular
+// definitions, components register themselves in a side-effect of their module.
+import './Text.ts';
+
+import { Component } from '../classes/Component.ts';
+import type { ChangeInformation } from '../utilities/changes.ts';
+import { registerComponent } from '../utilities/components.ts';
+import { create } from '../utilities/dom.ts';
+import { QNS } from '../utilities/namespaces.ts';
+import { evaluateXPathToMap } from '../utilities/xquery.ts';
+
+/**
+ * A type for indicating the start of a range of moved text. In OOXML, these are self-closing tags.
+ */
+export type MoveRangeEndChild = never;
+
+export type MoveRangeEndProps = Pick<ChangeInformation, 'id'> & {
+	type: 'from' | 'to';
+};
+
+/**
+ * A component that represents a change-tracked text that was inserted.
+ */
+export class MoveRangeEnd extends Component<
+	MoveRangeEndProps,
+	MoveRangeEndChild
+> {
+	public static override readonly children: string[] = [];
+	public static override readonly mixed: boolean = false;
+
+	/**
+	 * Creates an XML DOM node for this component instance.
+	 */
+	public override toNode(): Node {
+		return create(
+			`
+				switch ($type)
+				case 'to' return 
+				element ${QNS.w}moveToRangeEnd {
+					attribute ${QNS.w}id { $id }
+				}
+				case 'from' return 
+				element ${QNS.w}moveFromRangeEnd { 
+					attribute ${QNS.w}id { $id }
+				}
+				default return ()
+			`,
+			{
+				type: this.props.type,
+				id: this.props.id,
+			}
+		);
+	}
+
+	/**
+	 * Asserts whether or not a given XML node correlates with this component.
+	 */
+	static override matchesNode(node: Node): boolean {
+		return (
+			node.nodeName === 'w:moveFromRangeEnd' ||
+			node.nodeName === 'w:moveToRangeEnd'
+		);
+	}
+
+	/**
+	 * Instantiate this component from the XML in an existing DOCX file.
+	 */
+	static override fromNode(node: Node): MoveRangeEnd {
+		const type = node.nodeName === 'w:moveFromRangeEnd' ? 'from' : 'to';
+		const { id } = evaluateXPathToMap<{
+			id: number;
+		}>(
+			`map { 
+				"id": ./@${QNS.w}id/number()
+			}`,
+			node
+		);
+		return new MoveRangeEnd({
+			type: type,
+			id: id,
+		});
+	}
+}
+
+registerComponent(MoveRangeEnd);

--- a/src/components/MoveRangeEnd.ts
+++ b/src/components/MoveRangeEnd.ts
@@ -3,23 +3,21 @@
 import './Text.ts';
 
 import { Component } from '../classes/Component.ts';
-import type { ChangeInformation } from '../utilities/changes.ts';
 import { registerComponent } from '../utilities/components.ts';
 import { create } from '../utilities/dom.ts';
 import { QNS } from '../utilities/namespaces.ts';
 import { evaluateXPathToMap } from '../utilities/xquery.ts';
 
-/**
- * A type for indicating the start of a range of moved text. In OOXML, these are self-closing tags.
- */
 export type MoveRangeEndChild = never;
 
-export type MoveRangeEndProps = Pick<ChangeInformation, 'id'> & {
+export type MoveRangeEndProps = {
+	id: number;
 	type: 'from' | 'to';
 };
 
 /**
- * A component that represents a change-tracked text that was inserted.
+ * A type for indicating the end of a range of moved content.
+ * In OOXML, these are self-closing tags.
  */
 export class MoveRangeEnd extends Component<
 	MoveRangeEndProps,

--- a/src/components/MoveRangeStart.test.ts
+++ b/src/components/MoveRangeStart.test.ts
@@ -1,0 +1,78 @@
+import { expect } from 'std/expect';
+import { describe, it } from 'std/testing/bdd';
+
+import { MoveRangeStart } from './MoveRangeStart.ts';
+
+import { create, serialize } from '../utilities/dom.ts';
+import { NamespaceUri } from '../utilities/namespaces.ts';
+
+describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
+	const date = new Date();
+	const moveToRangeStart = MoveRangeStart.fromNode(
+		create(
+			`<w:moveToRangeStart xmlns:w="${
+				NamespaceUri.w
+			}" w:id="0" w:date="${date.toISOString()}" w:author="Gabe" w:name="Move_to_1" />`
+		)
+	);
+
+	const moveFromRangeStart = MoveRangeStart.fromNode(
+		create(
+			`<w:moveFromRangeStart xmlns:w="${
+				NamespaceUri.w
+			}" w:id="1" w:date="${date.toISOString()}" w:author="Angel" w:name="Move_from_1" />`
+		)
+	);
+	it('Create MoveToRangeStart from node', () => {
+		expect(moveToRangeStart.props.author).toBe('Gabe');
+		expect(moveToRangeStart.props.date).toBe(date.toISOString());
+		expect(moveToRangeStart.props.id).toBe(0);
+		expect(moveToRangeStart.props.name).toBe('Move_to_1');
+		expect(moveToRangeStart.props.type).toBe('to');
+	});
+
+	it('Create MoveFromRangeStart from node', () => {
+		expect(moveFromRangeStart.props.type).toBe('from');
+		expect(moveFromRangeStart.props.author).toBe('Angel');
+	});
+
+	it('Create MoveToRangeStart node from MoveRangeStart object', () => {
+		const toRangeObject = new MoveRangeStart({
+			id: 2,
+			date: date,
+			author: 'Gabe',
+			type: 'to',
+			name: 'To_Range_Object',
+		});
+
+		expect(serialize(toRangeObject.toNode())).toBe(
+			serialize(
+				create(
+					`<moveToRangeStart xmlns="${NamespaceUri.w}" xmlns:ns1="${
+						NamespaceUri.w
+					}" ns1:id="2" ns1:date="${date.toISOString()}" ns1:author="Gabe" ns1:name="To_Range_Object" />`
+				)
+			)
+		);
+	});
+
+	it('Create MoveFromRangeStart node from MoveRangeStart object', () => {
+		const toRangeObject = new MoveRangeStart({
+			id: 3,
+			date: date,
+			author: 'Angel',
+			type: 'from',
+			name: 'From_Range_Object',
+		});
+
+		expect(serialize(toRangeObject.toNode())).toBe(
+			serialize(
+				create(
+					`<moveFromRangeStart xmlns="${NamespaceUri.w}" xmlns:ns1="${
+						NamespaceUri.w
+					}" ns1:id="3" ns1:date="${date.toISOString()}" ns1:author="Angel" ns1:name="From_Range_Object" />`
+				)
+			)
+		);
+	});
+});

--- a/src/components/MoveRangeStart.ts
+++ b/src/components/MoveRangeStart.ts
@@ -1,0 +1,96 @@
+// Import without assignment ensures Deno does not tree-shake this component. To avoid circular
+// definitions, components register themselves in a side-effect of their module.
+import './Text.ts';
+
+import { Component } from '../classes/Component.ts';
+import type { ChangeInformation } from '../utilities/changes.ts';
+import { registerComponent } from '../utilities/components.ts';
+import { create } from '../utilities/dom.ts';
+import { QNS } from '../utilities/namespaces.ts';
+import { evaluateXPathToMap } from '../utilities/xquery.ts';
+
+export type MoveRangeStartProps = ChangeInformation & {
+	name: string;
+	type: 'from' | 'to';
+};
+
+export type MoveRangeStartChild = never;
+
+/**
+ * A component that represents a change-tracked text that was inserted.
+ */
+export class MoveRangeStart extends Component<
+	MoveRangeStartProps,
+	MoveRangeStartChild
+> {
+	/**
+	 * Creates an XML DOM node for this component instance.
+	 */
+	public override toNode(): Node {
+		return create(
+			`	let $attrs := [
+					attribute ${QNS.w}id { $id }, 
+					attribute ${QNS.w}date { $date }, 
+					attribute ${QNS.w}author { $author }, 
+					attribute ${QNS.w}name { $name }
+				]
+				return (
+					switch ($type)
+					case 'to' return 
+					element ${QNS.w}moveToRangeStart {
+						$attrs
+					}
+					case 'from' return 
+					element ${QNS.w}moveFromRangeStart {
+						$attrs
+					}
+					default return ()
+				)	
+			`,
+			{
+				...this.props,
+				date: this.props.date.toISOString(),
+			}
+		);
+	}
+
+	/**
+	 * Asserts whether or not a given XML node correlates with this component.
+	 */
+	static override matchesNode(node: Node): boolean {
+		return (
+			node.nodeName === 'w:moveFromRangeStart' ||
+			node.nodeName === 'w:moveToRangeStart'
+		);
+	}
+
+	/**
+	 * Instantiate this component from the XML in an existing DOCX file.
+	 */
+	static override fromNode(node: Node): MoveRangeStart {
+		const type = node.nodeName === 'w:moveFromRangeStart' ? 'from' : 'to';
+		const { id, name, date, author } = evaluateXPathToMap<{
+			id: number;
+			name: string;
+			date: Date;
+			author: string;
+		}>(
+			`map { 
+				"id": ./@${QNS.w}id/number(), 
+				"name": ./@${QNS.w}name/string(),
+				"date": ./@${QNS.w}date/string(),
+				"author": ./@${QNS.w}author/string()
+			}`,
+			node
+		);
+		return new MoveRangeStart({
+			type: type,
+			id: id,
+			name: name,
+			date: date,
+			author: author,
+		});
+	}
+}
+
+registerComponent(MoveRangeStart);

--- a/src/components/MoveRangeStart.ts
+++ b/src/components/MoveRangeStart.ts
@@ -17,7 +17,8 @@ export type MoveRangeStartProps = ChangeInformation & {
 export type MoveRangeStartChild = never;
 
 /**
- * A component that represents a change-tracked text that was inserted.
+ * A type for indicating the start of a range of moved content. 
+ * In OOXML, these are self-closing tags.
  */
 export class MoveRangeStart extends Component<
 	MoveRangeStartProps,

--- a/src/components/Paragraph.ts
+++ b/src/components/Paragraph.ts
@@ -42,6 +42,8 @@ import type { Field } from './Field.ts';
 import type { FootnoteAnchor } from './FootnoteAnchor.ts';
 import type { FootnoteReference } from './FootnoteReference.ts';
 import type { Move } from './Move.ts';
+import type { MoveRangeEnd } from './MoveRangeEnd.ts';
+import type { MoveRangeStart } from './MoveRangeStart.ts';
 import type { Text } from './Text.ts';
 import type { TextAddition } from './TextAddition.ts';
 import type { TextDeletion } from './TextDeletion.ts';
@@ -62,6 +64,8 @@ export type ParagraphChild =
 	| Field
 	| FootnoteReference
 	| Move
+	| MoveRangeEnd
+	| MoveRangeStart
 	| FootnoteAnchor;
 
 /**
@@ -93,6 +97,8 @@ export class Paragraph extends Component<ParagraphProps, ParagraphChild> {
 		'FootnoteReference',
 		'FootnoteAnchor',
 		'Move',
+		'MoveRangeEnd',
+		'MoveRangeStart',
 	];
 	public static override readonly mixed: boolean = false;
 	#sectionProperties: SectionProperties | null = null;
@@ -180,7 +186,11 @@ export class Paragraph extends Component<ParagraphProps, ParagraphChild> {
 						${QNS.w}bookmarkStart |
 						${QNS.w}bookmarkEnd | 
 						${QNS.w}moveTo | 
-						${QNS.w}moveFrom 
+						${QNS.w}moveFrom | 
+						${QNS.w}moveFromRangeStart
+						${QNS.w}moveFromRangeEnd | 
+						${QNS.w}moveToRangeStart | 
+						${QNS.w}moveToRangeEnd 
 					) }
 				}
 			`,

--- a/src/components/Paragraph.ts
+++ b/src/components/Paragraph.ts
@@ -187,7 +187,7 @@ export class Paragraph extends Component<ParagraphProps, ParagraphChild> {
 						${QNS.w}bookmarkEnd | 
 						${QNS.w}moveTo | 
 						${QNS.w}moveFrom | 
-						${QNS.w}moveFromRangeStart
+						${QNS.w}moveFromRangeStart |
 						${QNS.w}moveFromRangeEnd | 
 						${QNS.w}moveToRangeStart | 
 						${QNS.w}moveToRangeEnd 


### PR DESCRIPTION
This PR expands on the addition of the `Move` class with the `MoveRangeStart` and `MoveRangeEnd` classes. These allow us to indicate the extent of moved content in a Word document. 