### PR TITLE
Add `change` property to `TextProperties` to support track-changes for text styles 

### DIFF
--- a/examples/track-changes/track-changes-text-properties.jsx
+++ b/examples/track-changes/track-changes-text-properties.jsx
@@ -1,0 +1,59 @@
+/** @jsx  Docx.jsx */
+import Docx, {
+	Paragraph,
+	Section,
+	Text,
+	TextAddition,
+	TextDeletion,
+} from '../../mod.ts';
+
+// Create a new .docx file with track changes enabled.
+const docxFile = Docx.fromNothing().withSettings({
+	isTrackChangesEnabled: true,
+});
+
+// Create a new paragraph that includes text, a text deletion, and a text addition.
+const testParagraph = new Paragraph(
+	{},
+	new Text({}, 'Hello, '),
+	new TextDeletion(
+		{
+			id: 2,
+			author: 'Gabe',
+			date: new Date(),
+		},
+		new Text({}, 'nighttime')
+	),
+	new TextAddition(
+		{ id: 2, author: 'Paul Simon', date: new Date() },
+		new Text({}, 'darkness')
+	),
+	new Text({}, ' my old friend.'),
+
+	// This will set our current text style as italics. It will also create a recorded change
+	// that indicates the text style **was** bold, but is no longer.
+	new TextAddition(
+		{ id: 1, author: 'Gabe', date: new Date() },
+		new Text(
+			{
+				isItalic: true,
+				change: {
+					author: 'Gabe',
+					id: 22,
+					date: new Date(),
+					isBold: true,
+				},
+			},
+			` I've come to talk with you again.`
+		)
+	)
+);
+
+// Create a section as the parent of our new paragraph.
+const testSection = new Section({}, testParagraph);
+
+// Set that section as the content of our document.
+docxFile.document.set(testSection);
+
+// Save our document.
+await docxFile.toFile('track-text-property-changes.docx');

--- a/examples/track-changes/track-changes-text-properties.jsx
+++ b/examples/track-changes/track-changes-text-properties.jsx
@@ -36,12 +36,14 @@ const testParagraph = new Paragraph(
 		{ id: 1, author: 'Gabe', date: new Date() },
 		new Text(
 			{
+				color: 'red',
 				isItalic: true,
 				change: {
 					author: 'Gabe',
 					id: 22,
 					date: new Date(),
 					isBold: true,
+					color: 'blue',
 				},
 			},
 			` I've come to talk with you again.`

--- a/lib/properties/src/text-properties.ts
+++ b/lib/properties/src/text-properties.ts
@@ -22,10 +22,6 @@ function explodeSimpleOrComplex<Generic>(
 	if (value === null) {
 		return { simple: null, complex: null };
 	}
-	if (typeof value === 'boolean') {
-		(value as SimpleOrComplex<Generic>).simple === false &&
-			(value as SimpleOrComplex<Generic>).complex === false;
-	}
 	if (
 		(value as SimpleOrComplex<Generic>).simple === undefined &&
 		(value as SimpleOrComplex<Generic>).complex === undefined
@@ -144,7 +140,21 @@ export type TextProperties = {
 	 */
 	move?: MoveProps | null;
 
+	/**
+	 * A property used to indicate that the visual properties of this text have changed somehow.
+	 * Use with the {@link SettingsXml} settings for enabling track changes to visualize
+	 * how your document has changed.
+	 */
 	change?: (ChangeInformation & Omit<TextProperties, 'change'>) | null;
+};
+
+type IntermediateProps = Omit<TextProperties, 'change'> & {
+	change?: {
+		id: number;
+		author: string;
+		date: Date;
+		node: Node | undefined;
+	};
 };
 
 export function textPropertiesFromNode(node?: Node | null): TextProperties {
@@ -159,8 +169,7 @@ export function textPropertiesFromNode(node?: Node | null): TextProperties {
 	);
 
 	const props = node
-		? // deno-lint-ignore no-explicit-any
-		  evaluateXPathToMap<any>(
+		? evaluateXPathToMap<IntermediateProps>(
 				`map {
 			"style": ./${QNS.w}rStyle/@${QNS.w}val/string(),
 			"color": ./${QNS.w}color/@${QNS.w}val/string(),
@@ -200,7 +209,7 @@ export function textPropertiesFromNode(node?: Node | null): TextProperties {
 				"id": @${QNS.w}id/number(), 
 				"author": @${QNS.w}author/string(), 
 				"date": @${QNS.w}date/string(), 
-				"_node": ./${QNS.w}rPr
+				"node": ./${QNS.w}rPr
 			}
 		}`,
 				node,
@@ -213,8 +222,8 @@ export function textPropertiesFromNode(node?: Node | null): TextProperties {
 		props.change = {
 			...props.change,
 			date: new Date(props.change.date),
-			...textPropertiesFromNode(props.change._node),
-			_node: undefined,
+			...textPropertiesFromNode(props.change.node),
+			node: undefined,
 		};
 	} else {
 		delete props.change;
@@ -225,7 +234,7 @@ export function textPropertiesFromNode(node?: Node | null): TextProperties {
 		props.move.date = new Date(props.move.date);
 	}
 
-	return props;
+	return props as TextProperties;
 }
 
 export async function textPropertiesToNode(

--- a/lib/properties/src/text-properties.ts
+++ b/lib/properties/src/text-properties.ts
@@ -2,6 +2,7 @@ import {
 	Move,
 	type MoveProps,
 } from '../../components/track-changes/src/Move.ts';
+import type { ChangeInformation } from '../../utilities/src/changes.ts';
 import { create } from '../../utilities/src/dom.ts';
 import type { Length } from '../../utilities/src/length.ts';
 import { NamespaceUri, QNS } from '../../utilities/src/namespaces.ts';
@@ -141,9 +142,12 @@ export type TextProperties = {
 	move?: MoveProps | null;
 
 	/**
-	 * A property used to indicate that the visual properties of this text have changed somehow.
-	 * Use with the {@link SettingsXml} settings for enabling track changes to visualize
-	 * how your document has changed.
+	 * A property used to indicate that the way this text is deiplayed has changed somehow.
+	 * When track changes are enabled in Word, these properties will apppear as
+	 * having been editied.
+	 *
+	 * Move information about text run propertie can be found here:
+	 * https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_rPrChange_topic_ID0E4JSW.html?hl=rprchange
 	 */
 	change?: (ChangeInformation & Omit<TextProperties, 'change'>) | null;
 };

--- a/lib/properties/src/text-properties.ts
+++ b/lib/properties/src/text-properties.ts
@@ -138,6 +138,8 @@ export type TextProperties = {
 	 * Read more here:  https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_moveTo_topic_ID0EXMJW.html
 	 */
 	move?: MoveProps | null;
+
+	change?: (Omit<TextProperties, 'change'> & ChangeInformation) | null;
 };
 
 export function textPropertiesFromNode(node?: Node | null): TextProperties {
@@ -218,7 +220,8 @@ export async function textPropertiesToNode(
 		!data.isStrike &&
 		!data.shading &&
 		!data.font &&
-		!data.move
+		!data.move &&
+		!data.change
 	) {
 		return null;
 	}
@@ -270,8 +273,15 @@ export async function textPropertiesToNode(
 				if (exists($font('hAnsi'))) then attribute ${QNS.w}hAnsi {
 					$font('hAnsi')
 				} else ()
-			} else (), 
+			} else (),
+		if (exists($change)) then element rPrChange { 
+			attribute id { $change('id') },
+			attribute date { $change('date') },
+			attribute author { $change('author') }, 
+			$change('node')
+		} else () , 
 			$move
+
 		}`,
 		{
 			style: data.style || null,
@@ -307,6 +317,14 @@ export async function textPropertiesToNode(
 							hAnsi: data.font.hAnsi || null,
 					  }
 					: null,
+			change: data.change
+				? {
+						id: data.change.id,
+						date: new Date(data.change.date).toISOString(),
+						author: data.change.author,
+						node: textPropertiesToNode(data.change),
+				  }
+				: null,
 			/*
 			 * Although the Move component is used here and it can have children,
 			 * since the move information is sent as properties rather than as an

--- a/lib/properties/src/text-properties.ts
+++ b/lib/properties/src/text-properties.ts
@@ -15,11 +15,16 @@ type SimpleOrComplex<Generic> = {
 	simple?: Generic | null;
 	complex?: Generic | null;
 };
+
 function explodeSimpleOrComplex<Generic>(
 	value: Generic | SimpleOrComplex<Generic> | null
 ): Required<SimpleOrComplex<Generic>> | null {
 	if (value === null) {
 		return { simple: null, complex: null };
+	}
+	if (typeof value === 'boolean') {
+		(value as SimpleOrComplex<Generic>).simple === false &&
+			(value as SimpleOrComplex<Generic>).complex === false;
 	}
 	if (
 		(value as SimpleOrComplex<Generic>).simple === undefined &&
@@ -90,7 +95,7 @@ export type TextProperties = {
 	/**
 	 * Display text with a slant, or not.
 	 */
-	isItalic?: boolean | SimpleOrComplex<boolean> | null;
+	isItalic?: SimpleOrComplex<boolean> | null;
 	/**
 	 * Display text as capital letters, or not.
 	 */
@@ -139,7 +144,7 @@ export type TextProperties = {
 	 */
 	move?: MoveProps | null;
 
-	change?: (Omit<TextProperties, 'change'> & ChangeInformation) | null;
+	change?: (ChangeInformation & Omit<TextProperties, 'change'>) | null;
 };
 
 export function textPropertiesFromNode(node?: Node | null): TextProperties {
@@ -153,8 +158,10 @@ export function textPropertiesFromNode(node?: Node | null): TextProperties {
 		node
 	);
 
-	const props = evaluateXPathToMap<TextProperties>(
-		`map {
+	const props = node
+		? // deno-lint-ignore no-explicit-any
+		  evaluateXPathToMap<any>(
+				`map {
 			"style": ./${QNS.w}rStyle/@${QNS.w}val/string(),
 			"color": ./${QNS.w}color/@${QNS.w}val/string(),
 			"shading": ./${QNS.w}shd/docxml:ct-shd(.),
@@ -188,12 +195,30 @@ export function textPropertiesFromNode(node?: Node | null): TextProperties {
 				"author": @${QNS.w}author/string(), 
 				"date": @${QNS.w}date/string(),
 				"type": if ($nodeName eq 'moveTo') then 'to' else 'from'
+			}, 
+			"change": ./${QNS.w}rPrChange/map { 
+				"id": @${QNS.w}id/number(), 
+				"author": @${QNS.w}author/string(), 
+				"date": @${QNS.w}date/string(), 
+				"_node": ./${QNS.w}rPr
 			}
 		}`,
-		node,
-		null,
-		{ nodeName: nodeName ? nodeName.localName : null }
-	);
+				node,
+				null,
+				{ nodeName: nodeName ? nodeName.localName : null }
+		  )
+		: {};
+
+	if (props.change) {
+		props.change = {
+			...props.change,
+			date: new Date(props.change.date),
+			...textPropertiesFromNode(props.change._node),
+			_node: undefined,
+		};
+	} else {
+		delete props.change;
+	}
 
 	if (props.move) {
 		// Convert the date string to a Date object.
@@ -274,14 +299,13 @@ export async function textPropertiesToNode(
 					$font('hAnsi')
 				} else ()
 			} else (),
-		if (exists($change)) then element rPrChange { 
-			attribute id { $change('id') },
-			attribute date { $change('date') },
-			attribute author { $change('author') }, 
-			$change('node')
-		} else () , 
+			if (exists($change)) then element ${QNS.w}rPrChange { 
+				attribute ${QNS.w}date { $change('date') },
+				attribute ${QNS.w}id { $change('id') },
+				attribute ${QNS.w}author { $change('author') }, 
+				$change('node')
+			} else (),
 			$move
-
 		}`,
 		{
 			style: data.style || null,
@@ -320,9 +344,9 @@ export async function textPropertiesToNode(
 			change: data.change
 				? {
 						id: data.change.id,
-						date: new Date(data.change.date).toISOString(),
 						author: data.change.author,
-						node: textPropertiesToNode(data.change),
+						date: new Date(data.change.date).toISOString(),
+						node: await textPropertiesToNode(data.change),
 				  }
 				: null,
 			/*

--- a/lib/properties/src/text-properties.ts
+++ b/lib/properties/src/text-properties.ts
@@ -95,7 +95,7 @@ export type TextProperties = {
 	/**
 	 * Display text with a slant, or not.
 	 */
-	isItalic?: SimpleOrComplex<boolean> | null;
+	isItalic?: boolean | SimpleOrComplex<boolean> | null;
 	/**
 	 * Display text as capital letters, or not.
 	 */

--- a/lib/properties/test/text-properties.test.ts
+++ b/lib/properties/test/text-properties.test.ts
@@ -33,6 +33,12 @@ describe('Text formatting', () => {
 				<w:spacing w:val="100" />
 				<w:rFonts w:cs="Tahoma" w:ascii="Arial" w:hAnsi="Courier New" />
 				<w:moveTo w:author="Gabe" w:date="${date.toISOString()}" w:id="1" /> 
+				<w:rPrChange w:author="Angel" w:date="${date.toISOString()}" w:id="99" > 
+					<w:rPr>
+						<w:color w:val="blue" /> 
+						<w:b w:val="false" /> 
+					</w:rPr>
+				</w:rPrChange>
 			</w:rPr>`,
 		{
 			color: 'red',
@@ -61,6 +67,13 @@ describe('Text formatting', () => {
 				type: 'to',
 				date: date,
 				id: 1,
+			},
+			change: {
+				author: 'Angel',
+				date: date,
+				id: 99,
+				color: 'blue',
+				isBold: { simple: false, complex: false} 
 			},
 		}
 	);


### PR DESCRIPTION
This pr adds a `change` property to our `TextProperties` type. This enables the use of track-changes with the styles of individual runs of text. 