### PR TITLE
Add `change` property to `SectionProperties` class 

### DIFF
--- a/examples/track-changes/track-changes.tsx
+++ b/examples/track-changes/track-changes.tsx
@@ -6,6 +6,7 @@ import Docx, {
 	TextAddition,
 	TextDeletion,
 } from '../../mod.ts';
+import { inch } from '../../src/utilities/length.ts';
 
 // Create a new .docx file with track changes enabled.
 const docxFile = Docx.fromNothing().withSettings({
@@ -36,7 +37,21 @@ const testParagraph = new Paragraph(
 );
 
 // Create a section as the parent of our new paragraph.
-const testSection = new Section({}, testParagraph);
+const testSection = new Section(
+	{
+		pageWidth: inch(11),
+		pageHeight: inch(8.5),
+		change: {
+			id: 1,
+			author: 'Gabe',
+			date: new Date(),
+			pageOrientation: 'portrait',
+			pageWidth: inch(8.5),
+			pageHeight: inch(11),
+		},
+	},
+	testParagraph
+);
 
 // Set that section as the content of our document.
 docxFile.document.set(testSection);

--- a/src/properties/section-properties.test.ts
+++ b/src/properties/section-properties.test.ts
@@ -1,6 +1,6 @@
 import { describe } from 'std/testing/bdd';
 
-import { Length, twip } from '../utilities/length.ts';
+import { twip } from '../utilities/length.ts';
 import { ALL_NAMESPACE_DECLARATIONS } from '../utilities/namespaces.ts';
 import {
 	createObjectRoundRobinTest,
@@ -25,6 +25,41 @@ const reverseTest = createObjectRoundRobinTest<SectionProperties>(
 const date = new Date();
 
 describe('Section formatting', () => {
+	test(
+		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
+			<w:pgSz
+				w:w="1200"
+				w:h="1600"
+				w:orient="landscape"
+			/>
+			<w:pgMar
+				w:top="1000"
+				w:right="1000"
+				w:bottom="1000"
+				w:left="1000"
+				w:header="1000"
+				w:footer="1000"
+				w:gutter="1000"
+			/>
+		</w:sectPr>`,
+		{
+			pageWidth: twip(1200),
+			pageHeight: twip(1600),
+			pageOrientation: 'landscape',
+			pageMargin: {
+				top: twip(1000),
+				right: twip(1000),
+				bottom: twip(1000),
+				left: twip(1000),
+				header: twip(1000),
+				footer: twip(1000),
+				gutter: twip(1000),
+			},
+		}
+	);
+});
+
+describe('Section property change', () => {
 	test(
 		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
 			<w:pgSz w:orient="portrait"/>

--- a/src/properties/section-properties.test.ts
+++ b/src/properties/section-properties.test.ts
@@ -1,6 +1,6 @@
 import { describe } from 'std/testing/bdd';
 
-import { twip } from '../utilities/length.ts';
+import { Length, twip } from '../utilities/length.ts';
 import { ALL_NAMESPACE_DECLARATIONS } from '../utilities/namespaces.ts';
 import {
 	createObjectRoundRobinTest,
@@ -22,36 +22,26 @@ const reverseTest = createObjectRoundRobinTest<SectionProperties>(
 	sectionPropertiesFromNode
 );
 
+const date = new Date();
+
 describe('Section formatting', () => {
 	test(
 		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
-			<w:pgSz
-				w:w="1200"
-				w:h="1600"
-				w:orient="landscape"
-			/>
-			<w:pgMar
-				w:top="1000"
-				w:right="1000"
-				w:bottom="1000"
-				w:left="1000"
-				w:header="1000"
-				w:footer="1000"
-				w:gutter="1000"
-			/>
+			<w:pgSz w:orient="portrait"/>
+			<w:sectPrChange w:id="0" w:author="Gabe" w:date="${date.toISOString()}">
+				<w:sectPr>
+					<w:pgSz w:orient="portrait" w:w="12240" w:h="15840" /> 
+				</w:sectPr>
+			</w:sectPrChange> 
 		</w:sectPr>`,
 		{
-			pageWidth: twip(1200),
-			pageHeight: twip(1600),
-			pageOrientation: 'landscape',
-			pageMargin: {
-				top: twip(1000),
-				right: twip(1000),
-				bottom: twip(1000),
-				left: twip(1000),
-				header: twip(1000),
-				footer: twip(1000),
-				gutter: twip(1000),
+			pageOrientation: 'portrait',
+			change: {
+				id: 0,
+				author: 'Gabe',
+				date: date,
+				pageWidth: twip(12240),
+				pageHeight: twip(15840),
 			},
 		}
 	);
@@ -60,7 +50,7 @@ describe('Section formatting', () => {
 describe('Section column formatting for equally sized columns', () => {
 	test(
 		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
-			<w:cols w:num="3" w:equalWidth="1" w:sep="0" w:space="720"/> 
+			<w:cols w:num="3" w:equalWidth="1" w:sep="0" w:space="720"/>
 		</w:sectPr>`,
 		{
 			columns: {

--- a/src/properties/section-properties.ts
+++ b/src/properties/section-properties.ts
@@ -91,6 +91,15 @@ export type SectionProperties = {
 	change?: null | (Omit<SectionProperties, 'change'> & ChangeInformation);
 };
 
+type IntermediateProps = Omit<SectionProperties, 'change'> & {
+	change?: {
+		id: number;
+		author: string;
+		date: Date;
+		node: Node | undefined;
+	};
+};
+
 export function sectionPropertiesFromNode(
 	node?: Node | null
 ): SectionProperties {
@@ -99,8 +108,7 @@ export function sectionPropertiesFromNode(
 	}
 
 	const props = node
-		? // deno-lint-ignore no-explicit-any
-		  evaluateXPathToMap<any>(
+		? evaluateXPathToMap<IntermediateProps>(
 				`map {
 			"headers": map {
 				"first": ./${QNS.w}headerReference[@${QNS.w}type = 'first']/@${QNS.r}id/string(),
@@ -152,16 +160,14 @@ export function sectionPropertiesFromNode(
 		props.change = {
 			...props.change,
 			date: new Date(props.change.date),
-			...sectionPropertiesFromNode(props.change._node),
-			_node: undefined,
+			...sectionPropertiesFromNode(props.change.node),
+			node: undefined,
 		};
 	} else {
 		delete props.change;
 	}
 
-	// console.log(props);
-
-	return props;
+	return props as SectionProperties;
 }
 
 export function sectionPropertiesToNode(data: SectionProperties = {}): Node {

--- a/src/properties/section-properties.ts
+++ b/src/properties/section-properties.ts
@@ -149,7 +149,7 @@ export function sectionPropertiesFromNode(
 				"id": @${QNS.w}id/number(), 
 				"author": @${QNS.w}author/string(),
 				"date": @${QNS.w}date/string(),
-				"_node": ./${QNS.w}sectPr
+				"node": ./${QNS.w}sectPr
 			}
 		}`,
 				node

--- a/src/properties/section-properties.ts
+++ b/src/properties/section-properties.ts
@@ -1,4 +1,5 @@
 import type { FootnoteProps } from '../components/FootnoteReference.ts';
+import type { ChangeInformation } from '../utilities/changes.ts';
 import { create } from '../utilities/dom.ts';
 import type { Length } from '../utilities/length.ts';
 import { QNS } from '../utilities/namespaces.ts';
@@ -86,6 +87,8 @@ export type SectionProperties = {
 	 * Specifies whether sections in the document shall have different headers and footers for even and odd pages.
 	 */
 	isTitlePage?: null | boolean;
+
+	change?: null | (Omit<SectionProperties, 'change'> & ChangeInformation);
 };
 
 export function sectionPropertiesFromNode(
@@ -95,8 +98,10 @@ export function sectionPropertiesFromNode(
 		return {};
 	}
 
-	return evaluateXPathToMap<SectionProperties>(
-		`map {
+	const props = node
+		? // deno-lint-ignore no-explicit-any
+		  evaluateXPathToMap<any>(
+				`map {
 			"headers": map {
 				"first": ./${QNS.w}headerReference[@${QNS.w}type = 'first']/@${QNS.r}id/string(),
 				"even": ./${QNS.w}headerReference[@${QNS.w}type = 'even']/@${QNS.r}id/string(),
@@ -131,10 +136,32 @@ export function sectionPropertiesFromNode(
 				"footer": docxml:length(./${QNS.w}pgMar/@${QNS.w}footer, 'twip'),
 				"gutter": docxml:length(./${QNS.w}pgMar/@${QNS.w}gutter, 'twip')
 			},
-			"isTitlePage": exists(./${QNS.w}titlePg) and (not(./${QNS.w}titlePg/@${QNS.w}val) or docxml:st-on-off(./${QNS.w}titlePg/@${QNS.w}val))
+			"isTitlePage": exists(./${QNS.w}titlePg) and (not(./${QNS.w}titlePg/@${QNS.w}val) or docxml:st-on-off(./${QNS.w}titlePg/@${QNS.w}val)), 
+			"change": ./${QNS.w}sectPrChange/map { 
+				"id": @${QNS.w}id/number(), 
+				"author": @${QNS.w}author/string(),
+				"date": @${QNS.w}date/string(),
+				"_node": ./${QNS.w}sectPr
+			}
 		}`,
-		node
-	);
+				node
+		  ) || {}
+		: {};
+
+	if (props.change) {
+		props.change = {
+			...props.change,
+			date: new Date(props.change.date),
+			...sectionPropertiesFromNode(props.change._node),
+			_node: undefined,
+		};
+	} else {
+		delete props.change;
+	}
+
+	// console.log(props);
+
+	return props;
 }
 
 export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
@@ -232,8 +259,14 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 					round($pageMargin('gutter')('twip'))
 				} else ()
 			} else (),
-			if(exists($isTitlePage)) then element ${QNS.w}titlePg { attribute ${QNS.w}val { "1" } } else ()
-		}`,
+			if (exists($isTitlePage)) then element ${QNS.w}titlePg { attribute ${QNS.w}val { "1" } } else (), 
+			if (exists($change)) then element ${QNS.w}sectPrChange { 
+				attribute ${QNS.w}id { $change('id') }, 
+				attribute ${QNS.w}author { $change('author') },
+				attribute ${QNS.w}date { $change('date') }, 
+				$change('node')
+			} else ()
+ 		}`,
 		{
 			headers:
 				typeof data.headers === 'string'
@@ -258,6 +291,14 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 			pageMargin: data.pageMargin || null,
 			pageOrientation: data.pageOrientation || null,
 			isTitlePage: data.isTitlePage || null,
+			change: data.change
+				? {
+						id: data.change.id,
+						author: data.change.author,
+						date: data.change.date.toISOString(),
+						node: sectionPropertiesToNode(data.change),
+				  }
+				: null,
 		}
 	);
 }

--- a/src/utilities/tests.ts
+++ b/src/utilities/tests.ts
@@ -140,8 +140,6 @@ function localAssert(
 	const expectation = e1[prop as keyof typeof e1];
 	const reparsed = p2[prop as keyof typeof p2];
 
-	console.log('prop: ', prop);
-	console.log('p1', p1);
 	if (expectation && typeof expectation === 'object') {
 		describe(`.${String(prop)}`, () => {
 			if (Array.isArray(expectation)) {

--- a/src/utilities/tests.ts
+++ b/src/utilities/tests.ts
@@ -140,6 +140,8 @@ function localAssert(
 	const expectation = e1[prop as keyof typeof e1];
 	const reparsed = p2[prop as keyof typeof p2];
 
+	console.log('prop: ', prop);
+	console.log('p1', p1);
 	if (expectation && typeof expectation === 'object') {
 		describe(`.${String(prop)}`, () => {
 			if (Array.isArray(expectation)) {


### PR DESCRIPTION
This PR adds a change property to the SectionProperties class as a way to enable Word's track changes features for document sections.