### PR TITLE
Make author and date optional for ChangeInformation

### DIFF
--- a/examples/track-changes/track-changes-move.tsx
+++ b/examples/track-changes/track-changes-move.tsx
@@ -6,8 +6,6 @@ import Docx, {
 	Paragraph,
 	Section,
 	Text,
-	TextAddition,
-	TextDeletion,
 } from '../../mod.ts';
 
 // Create a new Word document with track changes enabled.

--- a/examples/track-changes/track-changes-move.tsx
+++ b/examples/track-changes/track-changes-move.tsx
@@ -46,6 +46,64 @@ const moveToParagraph = new Paragraph(
 	new MoveRangeEnd({
 		type: 'to',
 		id: 4,
+	}),
+	// Without date
+	new MoveRangeStart({
+		type: 'to',
+		name: 'move_1',
+		author: 'Inés',
+		id: 5,
+	}),
+	new Move(
+		{
+			type: 'to',
+			id: 5,
+			author: 'Inés',
+		},
+		new Text({}, 'To the people who look at the stars and wish.')
+	),
+	new MoveRangeEnd({
+		type: 'to',
+		id: 5,
+	}),
+	// Without author
+	new MoveRangeStart({
+		type: 'to',
+		name: 'move_2',
+		date: date,
+		id: 6,
+	}),
+	new Move(
+		{
+			type: 'to',
+			id: 6,
+			date: date,
+		},
+		new Text({}, 'There are different kinds of darkness.')
+	),
+	new MoveRangeEnd({
+		type: 'to',
+		id: 6,
+	}),
+	// Without author and date
+	new MoveRangeStart({
+		type: 'to',
+		name: 'move_3',
+		id: 7,
+	}),
+	new Move(
+		{
+			type: 'to',
+			id: 7,
+		},
+		new Text(
+			{},
+			'No one was my master— but I might be master of everything, if I wished. If I dared.'
+		)
+	),
+	new MoveRangeEnd({
+		type: 'to',
+		id: 7,
 	})
 );
 
@@ -87,6 +145,63 @@ const moveFromParagraph = new Paragraph(
 	new MoveRangeEnd({
 		type: 'from',
 		id: 4,
+	}),
+	// Without date
+	new MoveRangeStart({
+		type: 'from',
+		name: 'move_1',
+		author: 'Inés',
+		id: 5,
+	}),
+	new Move(
+		{
+			type: 'from',
+			id: 5,
+			author: 'Inés',
+		},
+		new Text({}, 'To the people who look at the stars and wish.')
+	),
+	new MoveRangeEnd({
+		type: 'from',
+		id: 5,
+	}),
+	// Without author
+	new MoveRangeStart({
+		type: 'from',
+		name: 'move_2',
+		id: 6,
+	}),
+	new Move(
+		{
+			type: 'from',
+			id: 6,
+			date: date,
+		},
+		new Text({}, 'There are different kinds of darkness.')
+	),
+	new MoveRangeEnd({
+		type: 'from',
+		id: 6,
+	}),
+	// Without author and date
+	new MoveRangeStart({
+		type: 'from',
+		name: 'move_3',
+		id: 7,
+	}),
+	new Move(
+		{
+			type: 'from',
+			id: 7,
+		},
+		new Text(
+			{},
+			'No one was my master— but I might be master of everything, if I wished. If I dared.'
+		)
+	),
+	new MoveRangeEnd({
+		type: 'from',
+		id: 7,
 	})
 );
 

--- a/examples/track-changes/track-changes-move.tsx
+++ b/examples/track-changes/track-changes-move.tsx
@@ -1,3 +1,4 @@
+/** @jsx  Docx.jsx */
 import Docx, {
 	Move,
 	MoveRangeEnd,
@@ -5,6 +6,8 @@ import Docx, {
 	Paragraph,
 	Section,
 	Text,
+	TextAddition,
+	TextDeletion,
 } from '../../mod.ts';
 
 // Create a new Word document with track changes enabled.
@@ -46,64 +49,6 @@ const moveToParagraph = new Paragraph(
 	new MoveRangeEnd({
 		type: 'to',
 		id: 4,
-	}),
-	// Without date
-	new MoveRangeStart({
-		type: 'to',
-		name: 'move_1',
-		author: 'Inés',
-		id: 5,
-	}),
-	new Move(
-		{
-			type: 'to',
-			id: 5,
-			author: 'Inés',
-		},
-		new Text({}, 'To the people who look at the stars and wish.')
-	),
-	new MoveRangeEnd({
-		type: 'to',
-		id: 5,
-	}),
-	// Without author
-	new MoveRangeStart({
-		type: 'to',
-		name: 'move_2',
-		date: date,
-		id: 6,
-	}),
-	new Move(
-		{
-			type: 'to',
-			id: 6,
-			date: date,
-		},
-		new Text({}, 'There are different kinds of darkness.')
-	),
-	new MoveRangeEnd({
-		type: 'to',
-		id: 6,
-	}),
-	// Without author and date
-	new MoveRangeStart({
-		type: 'to',
-		name: 'move_3',
-		id: 7,
-	}),
-	new Move(
-		{
-			type: 'to',
-			id: 7,
-		},
-		new Text(
-			{},
-			'No one was my master— but I might be master of everything, if I wished. If I dared.'
-		)
-	),
-	new MoveRangeEnd({
-		type: 'to',
-		id: 7,
 	})
 );
 
@@ -145,63 +90,6 @@ const moveFromParagraph = new Paragraph(
 	new MoveRangeEnd({
 		type: 'from',
 		id: 4,
-	}),
-	// Without date
-	new MoveRangeStart({
-		type: 'from',
-		name: 'move_1',
-		author: 'Inés',
-		id: 5,
-	}),
-	new Move(
-		{
-			type: 'from',
-			id: 5,
-			author: 'Inés',
-		},
-		new Text({}, 'To the people who look at the stars and wish.')
-	),
-	new MoveRangeEnd({
-		type: 'from',
-		id: 5,
-	}),
-	// Without author
-	new MoveRangeStart({
-		type: 'from',
-		name: 'move_2',
-		id: 6,
-	}),
-	new Move(
-		{
-			type: 'from',
-			id: 6,
-			date: date,
-		},
-		new Text({}, 'There are different kinds of darkness.')
-	),
-	new MoveRangeEnd({
-		type: 'from',
-		id: 6,
-	}),
-	// Without author and date
-	new MoveRangeStart({
-		type: 'from',
-		name: 'move_3',
-		id: 7,
-	}),
-	new Move(
-		{
-			type: 'from',
-			id: 7,
-		},
-		new Text(
-			{},
-			'No one was my master— but I might be master of everything, if I wished. If I dared.'
-		)
-	),
-	new MoveRangeEnd({
-		type: 'from',
-		id: 7,
 	})
 );
 
@@ -264,4 +152,54 @@ const section = new Section(
 docxFile.document.set(section);
 
 // Write to a file.
-docxFile.toFile('track-changes-move.docx');
+await docxFile.toFile('track-changes-move.docx');
+
+// Alternatively, you can use JSX:
+await Docx.fromJsx(
+	<Section>
+		<Paragraph pilcrow={{ move: { id: 1, type: 'to' } }}>
+			<MoveRangeStart id={2} type="to" name="move_0"></MoveRangeStart>
+			<Move id={3} type="to">
+				<Text>Memories exist outside of time</Text>
+			</Move>
+			<MoveRangeEnd id={4} type="to"></MoveRangeEnd>
+		</Paragraph>
+		<Paragraph>
+			<Text>
+				Silence is a space, a hollow where we take refuge, but where we
+				are never truly safe.
+			</Text>
+		</Paragraph>
+		<Paragraph pilcrow={{ move: { id: 1, type: 'from' } }}>
+			<MoveRangeStart id={2} type="from" name="move_0"></MoveRangeStart>
+			<Move id={3} type="from">
+				<Text>Memories exist outside of time</Text>
+			</Move>
+			<MoveRangeEnd id={4} type="from"></MoveRangeEnd>
+		</Paragraph>
+
+		<Paragraph>
+			<MoveRangeStart id={5} type="to" name="move_1"></MoveRangeStart>
+			<Move id={6} type="to">
+				<Text>
+					For none could tame our savage souls yet you the challenge
+					met,
+				</Text>
+			</Move>
+			<MoveRangeEnd id={7} type="to"></MoveRangeEnd>
+			<Text>
+				Under palest watch, you taught, we changed, base instincts were
+				redeemed,
+			</Text>
+			<MoveRangeStart id={5} type="from" name="move_1"></MoveRangeStart>
+			<Move id={6} author="Inés" type="from">
+				<Text>
+					{' '}
+					For none could tame our savage souls yet you the challenge
+					met,
+				</Text>
+			</Move>
+			<MoveRangeEnd id={7} type="from"></MoveRangeEnd>
+		</Paragraph>
+	</Section>
+).toFile('track-changes-move-jsx.docx');

--- a/lib/components/document/test/Paragraph.test.ts
+++ b/lib/components/document/test/Paragraph.test.ts
@@ -84,7 +84,7 @@ describe('Paragraph with style change', () => {
 						<pStyle xmlns:ns1="${NamespaceUri.w}" ns1:val="StyleNew"/>
 						<pPrChange xmlns:ns2="${
 							NamespaceUri.w
-						}" ns2:id="0" ns2:author="Wybe" ns2:date="${now.toISOString()}">
+						}" ns2:id="0" ns2:date="${now.toISOString()}" ns2:author="Wybe">
 							<pPr>
 								<pStyle ns2:val="StyleOld"/>
 						</pPr>

--- a/lib/components/track-changes/src/Move.ts
+++ b/lib/components/track-changes/src/Move.ts
@@ -93,8 +93,8 @@ export class Move extends Component<MoveProps, MoveChild> {
 				...this.props,
 				date: this.props.date
 					? new Date(this.props.date).toISOString()
-					: undefined,
-				author: this.props.author ? this.props.author : undefined,
+					: null,
+				author: this.props.author ? this.props.author : null,
 				children: await this.childrenToNode(ancestry),
 			}
 		);

--- a/lib/components/track-changes/src/Move.ts
+++ b/lib/components/track-changes/src/Move.ts
@@ -79,8 +79,8 @@ export class Move extends Component<MoveProps, MoveChild> {
 			`
 				let $attrs := [
 					attribute ${QNS.w}id { $id }, 
-					attribute ${QNS.w}date { $date }, 
-					attribute ${QNS.w}author { $author }
+					if ($date) then attribute ${QNS.w}date { $date } else (),
+					if ($author) then attribute ${QNS.w}author { $author } else ()
 				]
 				let $moveType := 
 					switch ($type)
@@ -91,7 +91,10 @@ export class Move extends Component<MoveProps, MoveChild> {
 			`,
 			{
 				...this.props,
-				date: new Date(this.props.date).toISOString(),
+				date: this.props.date
+					? new Date(this.props.date).toISOString()
+					: undefined,
+				author: this.props.author ? this.props.author : undefined,
 				children: await this.childrenToNode(ancestry),
 			}
 		);
@@ -128,12 +131,14 @@ export class Move extends Component<MoveProps, MoveChild> {
 					${QNS.w}moveFromRangeStart | 
 					${QNS.w}moveFromRangeEnd
 				)}, 
-				"changeProps": map { 
-					"id": @${QNS.w}id/number(),
-					"author": @${QNS.w}author/string(),
-					"date": @${QNS.w}date/string(),
-					"type": if ($nodeName eq 'moveTo') then 'to' else 'from'
-				}
+				"changeProps": map:merge((
+					map {
+						"id": @${QNS.w}id/number(),
+						"type": if ($nodeName eq 'moveTo') then 'to' else 'from'
+					},
+					if (@${QNS.w}date) then map { "date": @${QNS.w}date/string() } else map {},
+					if (@${QNS.w}author) then map { "author": @${QNS.w}author/string() } else map {}
+				))
 			}`,
 			node,
 			null,
@@ -142,7 +147,8 @@ export class Move extends Component<MoveProps, MoveChild> {
 		return new Move(
 			{
 				...changeProps,
-				date: new Date(changeProps.date),
+				date: changeProps.date ? new Date(changeProps.date) : undefined,
+				author: changeProps.author ? changeProps.author : undefined,
 			},
 			...createChildComponentsFromNodes<MoveChild>(
 				this.children,

--- a/lib/components/track-changes/src/Move.ts
+++ b/lib/components/track-changes/src/Move.ts
@@ -115,7 +115,8 @@ export class Move extends Component<MoveProps, MoveChild> {
 			children: Node[];
 			changeProps: MoveProps;
 		}>(
-			`map { 
+			`
+			map { 
 				"children": array{./(
 					${QNS.w}r |
 					${QNS.w}del |
@@ -131,14 +132,13 @@ export class Move extends Component<MoveProps, MoveChild> {
 					${QNS.w}moveFromRangeStart | 
 					${QNS.w}moveFromRangeEnd
 				)}, 
-				"changeProps": map:merge((
-					map {
-						"id": @${QNS.w}id/number(),
-						"type": if ($nodeName eq 'moveTo') then 'to' else 'from'
-					},
-					if (@${QNS.w}date) then map { "date": @${QNS.w}date/string() } else map {},
-					if (@${QNS.w}author) then map { "author": @${QNS.w}author/string() } else map {}
-				))
+				"changeProps": map { 
+					"id": @${QNS.w}id/number(),
+					"type": if ($nodeName eq 'moveTo') then 'to' else 'from',
+					"date": if (@${QNS.w}date) then @${QNS.w}date/string() else (),
+					"author": if (@${QNS.w}author) then @${QNS.w}author/string() else ()
+				}
+
 			}`,
 			node,
 			null,

--- a/lib/components/track-changes/src/MoveRangeStart.ts
+++ b/lib/components/track-changes/src/MoveRangeStart.ts
@@ -31,9 +31,9 @@ export class MoveRangeStart extends Component<
 		return create(
 			`	let $attrs := [
 					attribute ${QNS.w}id { $id }, 
-					attribute ${QNS.w}name { $name },
 					if ($date) then attribute ${QNS.w}date { $date } else (),
-					if ($author) then attribute ${QNS.w}author { $author } else ()
+					if ($author) then attribute ${QNS.w}author { $author } else (),
+					attribute ${QNS.w}name { $name }
 				]
 				return (
 					switch ($type)
@@ -50,10 +50,8 @@ export class MoveRangeStart extends Component<
 			`,
 			{
 				...this.props,
-				author: this.props.author ? this.props.author : undefined,
-				date: this.props.date
-					? this.props.date.toISOString()
-					: undefined,
+				author: this.props.author ? this.props.author : null,
+				date: this.props.date ? this.props.date.toISOString() : null,
 			}
 		);
 	}

--- a/lib/components/track-changes/src/MoveRangeStart.ts
+++ b/lib/components/track-changes/src/MoveRangeStart.ts
@@ -31,9 +31,9 @@ export class MoveRangeStart extends Component<
 		return create(
 			`	let $attrs := [
 					attribute ${QNS.w}id { $id }, 
-					attribute ${QNS.w}date { $date }, 
-					attribute ${QNS.w}author { $author }, 
-					attribute ${QNS.w}name { $name }
+					attribute ${QNS.w}name { $name },
+					if ($date) then attribute ${QNS.w}date { $date } else (),
+					if ($author) then attribute ${QNS.w}author { $author } else ()
 				]
 				return (
 					switch ($type)
@@ -50,7 +50,10 @@ export class MoveRangeStart extends Component<
 			`,
 			{
 				...this.props,
-				date: this.props.date.toISOString(),
+				author: this.props.author ? this.props.author : undefined,
+				date: this.props.date
+					? this.props.date.toISOString()
+					: undefined,
 			}
 		);
 	}
@@ -73,8 +76,8 @@ export class MoveRangeStart extends Component<
 		const { id, name, date, author } = evaluateXPathToMap<{
 			id: number;
 			name: string;
-			date: Date;
-			author: string;
+			date?: Date;
+			author?: string;
 		}>(
 			`map { 
 				"id": ./@${QNS.w}id/number(), 
@@ -88,8 +91,8 @@ export class MoveRangeStart extends Component<
 			type: type,
 			id: id,
 			name: name,
-			date: date,
-			author: author,
+			date: date ? date : undefined,
+			author: author ? author : undefined,
 		});
 	}
 }

--- a/lib/components/track-changes/src/RowAddition.ts
+++ b/lib/components/track-changes/src/RowAddition.ts
@@ -71,7 +71,7 @@ export class RowAddition extends Component<RowAdditionProps, RowAdditionChild> {
 				`,
 				{
 					...this.props,
-					date: this.props.date,
+					date: this.props.date?.toISOString(),
 				}
 			),
 			null

--- a/lib/components/track-changes/src/RowAddition.ts
+++ b/lib/components/track-changes/src/RowAddition.ts
@@ -71,7 +71,7 @@ export class RowAddition extends Component<RowAdditionProps, RowAdditionChild> {
 				`,
 				{
 					...this.props,
-					date: this.props.date.toISOString(),
+					date: this.props.date,
 				}
 			),
 			null

--- a/lib/components/track-changes/src/RowDeletion.ts
+++ b/lib/components/track-changes/src/RowDeletion.ts
@@ -60,6 +60,7 @@ export class RowDeletion extends Component<RowDeletionProps, RowDeletionChild> {
 			node.insertBefore(trPr, node.firstChild);
 		}
 
+		console.log('AAAAAAA ' + this.props.date);
 		trPr.insertBefore(
 			create(
 				`
@@ -71,7 +72,7 @@ export class RowDeletion extends Component<RowDeletionProps, RowDeletionChild> {
 				`,
 				{
 					...this.props,
-					date: this.props.date.toISOString(),
+					date: this.props.date?.toISOString(),
 				}
 			),
 			null

--- a/lib/components/track-changes/src/RowDeletion.ts
+++ b/lib/components/track-changes/src/RowDeletion.ts
@@ -60,7 +60,6 @@ export class RowDeletion extends Component<RowDeletionProps, RowDeletionChild> {
 			node.insertBefore(trPr, node.firstChild);
 		}
 
-		console.log('AAAAAAA ' + this.props.date);
 		trPr.insertBefore(
 			create(
 				`

--- a/lib/components/track-changes/src/TextAddition.ts
+++ b/lib/components/track-changes/src/TextAddition.ts
@@ -61,7 +61,7 @@ export class TextAddition extends Component<
 			`,
 			{
 				...this.props,
-				date: this.props.date.toISOString(),
+				date: this.props.date?.toISOString(),
 				children: await this.childrenToNode(ancestry),
 			}
 		);

--- a/lib/components/track-changes/src/TextDeletion.ts
+++ b/lib/components/track-changes/src/TextDeletion.ts
@@ -63,7 +63,7 @@ export class TextDeletion extends Component<
 			`,
 			{
 				...this.props,
-				date: this.props.date.toISOString(),
+				date: this.props.date?.toISOString(),
 				children: await this.childrenToNode(ancestry),
 			}
 		);

--- a/lib/components/track-changes/test/Move.test.ts
+++ b/lib/components/track-changes/test/Move.test.ts
@@ -29,10 +29,51 @@ describe('Move content in track changes...', () => {
 		emptyContext
 	);
 
+	const moveToNodeWithoutAuthor = create(
+		`<w:p xmlns:w="${NamespaceUri.w}">
+			<w:moveTo w:id="0" w:date="${date.toISOString()}">
+				<w:r>
+					<w:t xml:space="preserve">This is a paragraph</w:t>
+				</w:r>
+			</w:moveTo>
+		</w:p>`,
+		emptyContext
+	);
+	const moveToNodeWithoutDate = create(
+		`<w:p xmlns:w="${NamespaceUri.w}">
+			<w:moveTo w:id="0" w:author="Gabe">
+				<w:r>
+					<w:t xml:space="preserve">This is a paragraph</w:t>
+				</w:r>
+			</w:moveTo>
+		</w:p>`,
+		emptyContext
+	);
+
 	const moveFromNode = create(
 		`<w:moveFrom xmlns:w="${
 			NamespaceUri.w
 		}" w:id="1" w:author="Angel" w:date="${date.toISOString()}">
+            <w:r>
+                <w:t xml:space="preserve">This is a moveFrom node.</w:t>
+            </w:r>
+		</w:moveFrom>`,
+		emptyContext
+	);
+
+	const moveFromNodeWithoutAuthor = create(
+		`<w:moveFrom xmlns:w="${
+			NamespaceUri.w
+		}" w:id="1" w:date="${date.toISOString()}">
+            <w:r>
+                <w:t xml:space="preserve">This is a moveFrom node.</w:t>
+            </w:r>
+		</w:moveFrom>`,
+		emptyContext
+	);
+
+	const moveFromNodeWithoutDate = create(
+		`<w:moveFrom xmlns:w="${NamespaceUri.w}" w:id="1" w:author="Angel">
             <w:r>
                 <w:t xml:space="preserve">This is a moveFrom node.</w:t>
             </w:r>
@@ -45,6 +86,32 @@ describe('Move content in track changes...', () => {
 			<w:pPr>
 				<w:rPr>
 					<w:moveTo w:id="1" w:author="Luis" w:date="${date.toISOString()}" />
+				</w:rPr>
+			</w:pPr>
+			<w:r>
+				<w:t>Hello this is some text.</w:t>
+			</w:r>
+		</w:p>`
+	);
+
+	const moveToAsPropNodeWithoutAuthor = create(
+		`<w:p xmlns:w="${NamespaceUri.w}">
+			<w:pPr>
+				<w:rPr>
+					<w:moveTo w:id="1" w:date="${date.toISOString()}" />
+				</w:rPr>
+			</w:pPr>
+			<w:r>
+				<w:t>Hello this is some text.</w:t>
+			</w:r>
+		</w:p>`
+	);
+
+	const moveToAsPropNodeWithoutDate = create(
+		`<w:p xmlns:w="${NamespaceUri.w}">
+			<w:pPr>
+				<w:rPr>
+					<w:moveTo w:id="1" w:author="Luis" />
 				</w:rPr>
 			</w:pPr>
 			<w:r>
@@ -80,11 +147,52 @@ describe('Move content in track changes...', () => {
 		)
 	);
 
+	const moveToObjectWithoutDate = new Paragraph(
+		{ style: null },
+		new Move(
+			{
+				id: 0,
+				author: 'Gabe',
+				type: 'to',
+			},
+			new Text({}, 'This is a paragraph')
+		)
+	);
+
+	const moveToObjectWithoutAuthor = new Paragraph(
+		{ style: null },
+		new Move(
+			{
+				id: 0,
+				date: date,
+				type: 'to',
+			},
+			new Text({}, 'This is a paragraph')
+		)
+	);
+
 	// Testing a move as a stand-alone object
 	const moveFromObject = new Move(
 		{
 			id: 1,
 			date: date,
+			author: 'Angel',
+			type: 'from',
+		},
+		new Text({}, 'This is a moveFrom node.')
+	);
+
+	const moveFromObjectWithoutAuthor = new Move(
+		{
+			id: 1,
+			date: date,
+			type: 'from',
+		},
+		new Text({}, 'This is a moveFrom node.')
+	);
+	const moveFromObjectWithoutDate = new Move(
+		{
+			id: 1,
 			author: 'Angel',
 			type: 'from',
 		},
@@ -97,6 +205,32 @@ describe('Move content in track changes...', () => {
 				move: {
 					author: 'Luis',
 					date: date,
+					type: 'to',
+					id: 1,
+				},
+			},
+		},
+		new Text({}, 'Hello this is some text.')
+	);
+
+	const moveToAsPropObjectWithoutAuthor = new Paragraph(
+		{
+			pilcrow: {
+				move: {
+					date: date,
+					type: 'to',
+					id: 1,
+				},
+			},
+		},
+		new Text({}, 'Hello this is some text.')
+	);
+
+	const moveToAsPropObjectWithoutDate = new Paragraph(
+		{
+			pilcrow: {
+				move: {
+					author: 'Luis',
 					type: 'to',
 					id: 1,
 				},
@@ -120,8 +254,35 @@ describe('Move content in track changes...', () => {
 	);
 
 	const newMoveTo = Paragraph.fromNode(moveToNode, emptyContext);
+	const newMoveToWithoutAuthor = Paragraph.fromNode(
+		moveToNodeWithoutAuthor,
+		emptyContext
+	);
+	const newMoveToWithoutDate = Paragraph.fromNode(
+		moveToNodeWithoutDate,
+		emptyContext
+	);
+
 	const newMoveFrom = Move.fromNode(moveFromNode, emptyContext);
+	const newMoveFromWithoutAuthor = Move.fromNode(
+		moveFromNodeWithoutAuthor,
+		emptyContext
+	);
+	const newMoveFromWithoutDate = Move.fromNode(
+		moveFromNodeWithoutDate,
+		emptyContext
+	);
+
 	const newMoveToAsProp = Paragraph.fromNode(moveToAsPropNode, emptyContext);
+	const newMoveToAsPropWithoutAuthor = Paragraph.fromNode(
+		moveToAsPropNodeWithoutAuthor,
+		emptyContext
+	);
+	const newMoveToAsPropWithoutDate = Paragraph.fromNode(
+		moveToAsPropNodeWithoutDate,
+		emptyContext
+	);
+
 	const newMoveFromAsProp = Paragraph.fromNode(
 		moveFromAsPropNode,
 		emptyContext
@@ -129,10 +290,23 @@ describe('Move content in track changes...', () => {
 
 	it('turns node into expected Move objects', () => {
 		expect(newMoveTo).toEqual(moveToObject);
+		expect(newMoveToWithoutAuthor).toEqual(moveToObjectWithoutAuthor);
+		expect(newMoveToWithoutDate).toEqual(moveToObjectWithoutDate);
+
 		expect(newMoveFrom).toEqual(moveFromObject);
+		expect(newMoveFromWithoutAuthor).toEqual(moveFromObjectWithoutAuthor);
+		expect(newMoveFromWithoutDate).toEqual(moveFromObjectWithoutDate);
+
 		expect(newMoveToAsProp.props.pilcrow?.move).toEqual(
 			moveToAsPropObject.props.pilcrow?.move
 		);
+		expect(newMoveToAsPropWithoutAuthor.props.pilcrow?.move).toEqual(
+			moveToAsPropObjectWithoutAuthor.props.pilcrow?.move
+		);
+		expect(newMoveToAsPropWithoutDate.props.pilcrow?.move).toEqual(
+			moveToAsPropObjectWithoutDate.props.pilcrow?.move
+		);
+
 		expect(newMoveFromAsProp.props.pilcrow?.move).toEqual(
 			moveFromAsPropObject.props.pilcrow?.move
 		);

--- a/lib/components/track-changes/test/Move.test.ts
+++ b/lib/components/track-changes/test/Move.test.ts
@@ -132,6 +132,30 @@ describe('Move content in track changes...', () => {
 			</w:r>
 		</w:p>`
 	);
+	const moveFromAsPropNodeWithoutAuthor = create(
+		`<w:p xmlns:w="${NamespaceUri.w}">
+			<w:pPr>
+				<w:rPr>
+					<w:moveFrom w:id="2" w:date="${date.toISOString()}" />
+				</w:rPr>
+			</w:pPr>
+			<w:r>
+				<w:t>I'm just a poor boy</w:t>
+			</w:r>
+		</w:p>`
+	);
+	const moveFromAsPropNodeWithoutDate = create(
+		`<w:p xmlns:w="${NamespaceUri.w}">
+			<w:pPr>
+				<w:rPr>
+					<w:moveFrom w:id="2" w:author="Ines" />
+				</w:rPr>
+			</w:pPr>
+			<w:r>
+				<w:t>I'm just a poor boy</w:t>
+			</w:r>
+		</w:p>`
+	);
 
 	// Testing a move inside a paragraph.
 	const moveToObject = new Paragraph(
@@ -253,6 +277,33 @@ describe('Move content in track changes...', () => {
 		new Text({}, "I'm just a poor boy")
 	);
 
+	const moveFromAsPropObjectWithoutAuthor = new Paragraph(
+		{
+			pilcrow: {
+				move: {
+					id: 2,
+					date: date,
+					type: 'from',
+				},
+			},
+		},
+		new Text({}, "I'm just a poor boy")
+	);
+
+	const moveFromAsPropObjectWithoutDate = new Paragraph(
+		{
+			pilcrow: {
+				move: {
+					id: 2,
+					author: 'Ines',
+					type: 'from',
+				},
+			},
+		},
+		new Text({}, "I'm just a poor boy")
+	);
+
+	// MoveTo as an object
 	const newMoveTo = Paragraph.fromNode(moveToNode, emptyContext);
 	const newMoveToWithoutAuthor = Paragraph.fromNode(
 		moveToNodeWithoutAuthor,
@@ -263,6 +314,7 @@ describe('Move content in track changes...', () => {
 		emptyContext
 	);
 
+	// MoveFrom as an object
 	const newMoveFrom = Move.fromNode(moveFromNode, emptyContext);
 	const newMoveFromWithoutAuthor = Move.fromNode(
 		moveFromNodeWithoutAuthor,
@@ -273,6 +325,7 @@ describe('Move content in track changes...', () => {
 		emptyContext
 	);
 
+	// MoveTo as property
 	const newMoveToAsProp = Paragraph.fromNode(moveToAsPropNode, emptyContext);
 	const newMoveToAsPropWithoutAuthor = Paragraph.fromNode(
 		moveToAsPropNodeWithoutAuthor,
@@ -283,8 +336,17 @@ describe('Move content in track changes...', () => {
 		emptyContext
 	);
 
+	// MoveFrom as property
 	const newMoveFromAsProp = Paragraph.fromNode(
 		moveFromAsPropNode,
+		emptyContext
+	);
+	const newMoveFromAsPropWithoutAuthor = Paragraph.fromNode(
+		moveFromAsPropNodeWithoutAuthor,
+		emptyContext
+	);
+	const newMoveFromAsPropWithoutDate = Paragraph.fromNode(
+		moveFromAsPropNodeWithoutDate,
 		emptyContext
 	);
 
@@ -309,6 +371,12 @@ describe('Move content in track changes...', () => {
 
 		expect(newMoveFromAsProp.props.pilcrow?.move).toEqual(
 			moveFromAsPropObject.props.pilcrow?.move
+		);
+		expect(newMoveFromAsPropWithoutAuthor.props.pilcrow?.move).toEqual(
+			moveFromAsPropObjectWithoutAuthor.props.pilcrow?.move
+		);
+		expect(newMoveFromAsPropWithoutDate.props.pilcrow?.move).toEqual(
+			moveFromAsPropObjectWithoutDate.props.pilcrow?.move
 		);
 	});
 
@@ -337,6 +405,34 @@ describe('Move content in track changes...', () => {
 					`<moveFrom 
 						xmlns="${NamespaceUri.w}" xmlns:ns1="${NamespaceUri.w}"
 						ns1:id="1" ns1:date="${date.toISOString()}" ns1:author="Angel" >
+						<r>
+							<t xml:space="preserve" >This is a moveFrom node.</t>
+						</r>
+					</moveFrom>`
+				)
+			)
+		);
+
+		expect(serialize(await moveFromObjectWithoutAuthor.toNode([]))).toEqual(
+			serialize(
+				create(
+					`<moveFrom 
+						xmlns="${NamespaceUri.w}" xmlns:ns1="${NamespaceUri.w}"
+						ns1:id="1" ns1:date="${date.toISOString()}">
+						<r>
+							<t xml:space="preserve" >This is a moveFrom node.</t>
+						</r>
+					</moveFrom>`
+				)
+			)
+		);
+
+		expect(serialize(await moveFromObjectWithoutDate.toNode([]))).toEqual(
+			serialize(
+				create(
+					`<moveFrom 
+						xmlns="${NamespaceUri.w}" xmlns:ns1="${NamespaceUri.w}"
+						ns1:id="1" ns1:author="Angel">
 						<r>
 							<t xml:space="preserve" >This is a moveFrom node.</t>
 						</r>

--- a/lib/components/track-changes/test/MoveRangeStart.test.ts
+++ b/lib/components/track-changes/test/MoveRangeStart.test.ts
@@ -16,6 +16,19 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 		)
 	);
 
+	const moveToRangeStartWithoutAuthor = MoveRangeStart.fromNode(
+		create(
+			`<w:moveToRangeStart xmlns:w="${
+				NamespaceUri.w
+			}" w:id="1" w:date="${date.toISOString()}" w:name="Move_to_1" />`
+		)
+	);
+	const moveToRangeStartWithoutDate = MoveRangeStart.fromNode(
+		create(
+			`<w:moveToRangeStart xmlns:w="${NamespaceUri.w}" w:id="1" w:author="Angel" w:name="Move_to_1" />`
+		)
+	);
+
 	const moveFromRangeStart = MoveRangeStart.fromNode(
 		create(
 			`<w:moveFromRangeStart xmlns:w="${
@@ -23,6 +36,20 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 			}" w:id="1" w:date="${date.toISOString()}" w:author="Angel" w:name="Move_from_1" />`
 		)
 	);
+
+	const moveFromRangeStartWithoutAuthor = MoveRangeStart.fromNode(
+		create(
+			`<w:moveFromRangeStart xmlns:w="${
+				NamespaceUri.w
+			}" w:id="1" w:date="${date.toISOString()}" w:name="Move_from_1" />`
+		)
+	);
+	const moveFromRangeStartWithoutDate = MoveRangeStart.fromNode(
+		create(
+			`<w:moveFromRangeStart xmlns:w="${NamespaceUri.w}" w:id="1" w:author="Angel" w:name="Move_from_1" />`
+		)
+	);
+
 	it('Create MoveToRangeStart from node', () => {
 		expect(moveToRangeStart.props.author).toBe('Gabe');
 		expect(moveToRangeStart.props.date).toBe(date.toISOString());
@@ -31,9 +58,45 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 		expect(moveToRangeStart.props.type).toBe('to');
 	});
 
+	it('Create MoveToRangeStart without author from node', () => {
+		expect(moveToRangeStartWithoutAuthor.props.author).toBe(null);
+		expect(moveToRangeStartWithoutAuthor.props.date).toBe(
+			date.toISOString()
+		);
+		expect(moveToRangeStartWithoutAuthor.props.id).toBe(1);
+		expect(moveToRangeStartWithoutAuthor.props.name).toBe('Move_to_1');
+		expect(moveToRangeStartWithoutAuthor.props.type).toBe('to');
+	});
+
+	it('Create MoveToRangeStart without date from node', () => {
+		expect(moveToRangeStartWithoutDate.props.author).toBe('Angel');
+		expect(moveToRangeStartWithoutDate.props.date).toBe(null);
+		expect(moveToRangeStartWithoutDate.props.id).toBe(1);
+		expect(moveToRangeStartWithoutDate.props.name).toBe('Move_to_1');
+		expect(moveToRangeStartWithoutDate.props.type).toBe('to');
+	});
+
 	it('Create MoveFromRangeStart from node', () => {
 		expect(moveFromRangeStart.props.type).toBe('from');
 		expect(moveFromRangeStart.props.author).toBe('Angel');
+	});
+
+	it('Create MoveFromRangeStart without author from node', () => {
+		expect(moveFromRangeStartWithoutAuthor.props.author).toBe(null);
+		expect(moveFromRangeStartWithoutAuthor.props.date).toBe(
+			date.toISOString()
+		);
+		expect(moveFromRangeStartWithoutAuthor.props.id).toBe(1);
+		expect(moveFromRangeStartWithoutAuthor.props.name).toBe('Move_from_1');
+		expect(moveFromRangeStartWithoutAuthor.props.type).toBe('from');
+	});
+
+	it('Create MoveFromRangeStart without date from node', () => {
+		expect(moveFromRangeStartWithoutDate.props.author).toBe('Angel');
+		expect(moveFromRangeStartWithoutDate.props.date).toBe(null);
+		expect(moveFromRangeStartWithoutDate.props.id).toBe(1);
+		expect(moveFromRangeStartWithoutDate.props.name).toBe('Move_from_1');
+		expect(moveFromRangeStartWithoutDate.props.type).toBe('from');
 	});
 
 	it('Create MoveToRangeStart node from MoveRangeStart object', () => {
@@ -50,7 +113,7 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 				create(
 					`<moveToRangeStart xmlns="${NamespaceUri.w}" xmlns:ns1="${
 						NamespaceUri.w
-					}" ns1:id="2" ns1:name="To_Range_Object" ns1:date="${date.toISOString()}" ns1:author="Gabe" />`
+					}" ns1:id="2" ns1:date="${date.toISOString()}" ns1:author="Gabe" ns1:name="To_Range_Object" />`
 				)
 			)
 		);
@@ -70,7 +133,78 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 				create(
 					`<moveFromRangeStart xmlns="${NamespaceUri.w}" xmlns:ns1="${
 						NamespaceUri.w
-					}" ns1:id="3" ns1:name="From_Range_Object"  ns1:date="${date.toISOString()}" ns1:author="Angel"  />`
+					}" ns1:id="3" ns1:date="${date.toISOString()}" ns1:author="Angel" ns1:name="From_Range_Object" />`
+				)
+			)
+		);
+	});
+
+	it('Create MoveFromRangeStart node MoveRangeStart from object without author and date parameters', () => {
+		const toRangeObject = new MoveRangeStart({
+			id: 3,
+			type: 'from',
+			name: 'From_Range_Object',
+		});
+
+		expect(serialize(toRangeObject.toNode())).toBe(
+			serialize(
+				create(
+					`<moveFromRangeStart xmlns="${NamespaceUri.w}" xmlns:ns1="${NamespaceUri.w}" ns1:id="3" ns1:name="From_Range_Object" />`
+				)
+			)
+		);
+	});
+
+	it('Create MoveFromRangeStart node MoveRangeStart from object without author parameter', () => {
+		const toRangeObject = new MoveRangeStart({
+			id: 3,
+			type: 'from',
+			name: 'From_Range_Object',
+			author: 'Angel',
+		});
+
+		expect(serialize(toRangeObject.toNode())).toBe(
+			serialize(
+				create(
+					`<moveFromRangeStart xmlns="${NamespaceUri.w}" xmlns:ns1="${NamespaceUri.w}" ns1:id="3"  ns1:author="Angel" ns1:name="From_Range_Object" />`
+				)
+			)
+		);
+	});
+
+	it('Create MoveFromRangeStart node MoveRangeStart from object without date parameter', () => {
+		const toRangeObject = new MoveRangeStart({
+			id: 3,
+			type: 'from',
+			name: 'From_Range_Object',
+			date: date,
+		});
+
+		expect(serialize(toRangeObject.toNode())).toBe(
+			serialize(
+				create(
+					`<moveFromRangeStart xmlns="${NamespaceUri.w}" xmlns:ns1="${
+						NamespaceUri.w
+					}" ns1:id="3" ns1:date="${date.toISOString()}" ns1:name="From_Range_Object" />`
+				)
+			)
+		);
+	});
+
+	it('Create MoveToRangeStart node MoveRangeStart from object without date parameter', () => {
+		const toRangeObject = new MoveRangeStart({
+			id: 3,
+			type: 'to',
+			name: 'To_Range_Object',
+			date: date,
+		});
+
+		expect(serialize(toRangeObject.toNode())).toBe(
+			serialize(
+				create(
+					`<moveToRangeStart xmlns="${NamespaceUri.w}" xmlns:ns1="${
+						NamespaceUri.w
+					}" ns1:id="3" ns1:date="${date.toISOString()}" ns1:name="To_Range_Object" />`
 				)
 			)
 		);

--- a/lib/components/track-changes/test/MoveRangeStart.test.ts
+++ b/lib/components/track-changes/test/MoveRangeStart.test.ts
@@ -59,7 +59,7 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 	});
 
 	it('Create MoveToRangeStart without author from node', () => {
-		expect(moveToRangeStartWithoutAuthor.props.author).toBe(null);
+		expect(moveToRangeStartWithoutAuthor.props.author).toBe(undefined);
 		expect(moveToRangeStartWithoutAuthor.props.date).toBe(
 			date.toISOString()
 		);
@@ -70,7 +70,7 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 
 	it('Create MoveToRangeStart without date from node', () => {
 		expect(moveToRangeStartWithoutDate.props.author).toBe('Angel');
-		expect(moveToRangeStartWithoutDate.props.date).toBe(null);
+		expect(moveToRangeStartWithoutDate.props.date).toBe(undefined);
 		expect(moveToRangeStartWithoutDate.props.id).toBe(1);
 		expect(moveToRangeStartWithoutDate.props.name).toBe('Move_to_1');
 		expect(moveToRangeStartWithoutDate.props.type).toBe('to');
@@ -82,7 +82,7 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 	});
 
 	it('Create MoveFromRangeStart without author from node', () => {
-		expect(moveFromRangeStartWithoutAuthor.props.author).toBe(null);
+		expect(moveFromRangeStartWithoutAuthor.props.author).toBe(undefined);
 		expect(moveFromRangeStartWithoutAuthor.props.date).toBe(
 			date.toISOString()
 		);
@@ -93,7 +93,7 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 
 	it('Create MoveFromRangeStart without date from node', () => {
 		expect(moveFromRangeStartWithoutDate.props.author).toBe('Angel');
-		expect(moveFromRangeStartWithoutDate.props.date).toBe(null);
+		expect(moveFromRangeStartWithoutDate.props.date).toBe(undefined);
 		expect(moveFromRangeStartWithoutDate.props.id).toBe(1);
 		expect(moveFromRangeStartWithoutDate.props.name).toBe('Move_from_1');
 		expect(moveFromRangeStartWithoutDate.props.type).toBe('from');

--- a/lib/components/track-changes/test/MoveRangeStart.test.ts
+++ b/lib/components/track-changes/test/MoveRangeStart.test.ts
@@ -50,7 +50,7 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 				create(
 					`<moveToRangeStart xmlns="${NamespaceUri.w}" xmlns:ns1="${
 						NamespaceUri.w
-					}" ns1:id="2" ns1:date="${date.toISOString()}" ns1:author="Gabe" ns1:name="To_Range_Object" />`
+					}" ns1:id="2" ns1:name="To_Range_Object" ns1:date="${date.toISOString()}" ns1:author="Gabe" />`
 				)
 			)
 		);
@@ -70,7 +70,7 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 				create(
 					`<moveFromRangeStart xmlns="${NamespaceUri.w}" xmlns:ns1="${
 						NamespaceUri.w
-					}" ns1:id="3" ns1:date="${date.toISOString()}" ns1:author="Angel" ns1:name="From_Range_Object" />`
+					}" ns1:id="3" ns1:name="From_Range_Object"  ns1:date="${date.toISOString()}" ns1:author="Angel"  />`
 				)
 			)
 		);

--- a/lib/components/track-changes/test/MoveRangeStart.test.ts
+++ b/lib/components/track-changes/test/MoveRangeStart.test.ts
@@ -8,49 +8,15 @@ import { NamespaceUri } from '../../../utilities/src/namespaces.ts';
 
 describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 	const date = new Date();
-	const moveToRangeStart = MoveRangeStart.fromNode(
-		create(
-			`<w:moveToRangeStart xmlns:w="${
-				NamespaceUri.w
-			}" w:id="0" w:date="${date.toISOString()}" w:author="Gabe" w:name="Move_to_1" />`
-		)
-	);
-
-	const moveToRangeStartWithoutAuthor = MoveRangeStart.fromNode(
-		create(
-			`<w:moveToRangeStart xmlns:w="${
-				NamespaceUri.w
-			}" w:id="1" w:date="${date.toISOString()}" w:name="Move_to_1" />`
-		)
-	);
-	const moveToRangeStartWithoutDate = MoveRangeStart.fromNode(
-		create(
-			`<w:moveToRangeStart xmlns:w="${NamespaceUri.w}" w:id="1" w:author="Angel" w:name="Move_to_1" />`
-		)
-	);
-
-	const moveFromRangeStart = MoveRangeStart.fromNode(
-		create(
-			`<w:moveFromRangeStart xmlns:w="${
-				NamespaceUri.w
-			}" w:id="1" w:date="${date.toISOString()}" w:author="Angel" w:name="Move_from_1" />`
-		)
-	);
-
-	const moveFromRangeStartWithoutAuthor = MoveRangeStart.fromNode(
-		create(
-			`<w:moveFromRangeStart xmlns:w="${
-				NamespaceUri.w
-			}" w:id="1" w:date="${date.toISOString()}" w:name="Move_from_1" />`
-		)
-	);
-	const moveFromRangeStartWithoutDate = MoveRangeStart.fromNode(
-		create(
-			`<w:moveFromRangeStart xmlns:w="${NamespaceUri.w}" w:id="1" w:author="Angel" w:name="Move_from_1" />`
-		)
-	);
 
 	it('Create MoveToRangeStart from node', () => {
+		const moveToRangeStart = MoveRangeStart.fromNode(
+			create(
+				`<w:moveToRangeStart xmlns:w="${
+					NamespaceUri.w
+				}" w:id="0" w:date="${date.toISOString()}" w:author="Gabe" w:name="Move_to_1" />`
+			)
+		);
 		expect(moveToRangeStart.props.author).toBe('Gabe');
 		expect(moveToRangeStart.props.date).toBe(date.toISOString());
 		expect(moveToRangeStart.props.id).toBe(0);
@@ -59,6 +25,13 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 	});
 
 	it('Create MoveToRangeStart without author from node', () => {
+		const moveToRangeStartWithoutAuthor = MoveRangeStart.fromNode(
+			create(
+				`<w:moveToRangeStart xmlns:w="${
+					NamespaceUri.w
+				}" w:id="1" w:date="${date.toISOString()}" w:name="Move_to_1" />`
+			)
+		);
 		expect(moveToRangeStartWithoutAuthor.props.author).toBe(undefined);
 		expect(moveToRangeStartWithoutAuthor.props.date).toBe(
 			date.toISOString()
@@ -69,6 +42,11 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 	});
 
 	it('Create MoveToRangeStart without date from node', () => {
+		const moveToRangeStartWithoutDate = MoveRangeStart.fromNode(
+			create(
+				`<w:moveToRangeStart xmlns:w="${NamespaceUri.w}" w:id="1" w:author="Angel" w:name="Move_to_1" />`
+			)
+		);
 		expect(moveToRangeStartWithoutDate.props.author).toBe('Angel');
 		expect(moveToRangeStartWithoutDate.props.date).toBe(undefined);
 		expect(moveToRangeStartWithoutDate.props.id).toBe(1);
@@ -77,11 +55,25 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 	});
 
 	it('Create MoveFromRangeStart from node', () => {
+		const moveFromRangeStart = MoveRangeStart.fromNode(
+			create(
+				`<w:moveFromRangeStart xmlns:w="${
+					NamespaceUri.w
+				}" w:id="1" w:date="${date.toISOString()}" w:author="Angel" w:name="Move_from_1" />`
+			)
+		);
 		expect(moveFromRangeStart.props.type).toBe('from');
 		expect(moveFromRangeStart.props.author).toBe('Angel');
 	});
 
 	it('Create MoveFromRangeStart without author from node', () => {
+		const moveFromRangeStartWithoutAuthor = MoveRangeStart.fromNode(
+			create(
+				`<w:moveFromRangeStart xmlns:w="${
+					NamespaceUri.w
+				}" w:id="1" w:date="${date.toISOString()}" w:name="Move_from_1" />`
+			)
+		);
 		expect(moveFromRangeStartWithoutAuthor.props.author).toBe(undefined);
 		expect(moveFromRangeStartWithoutAuthor.props.date).toBe(
 			date.toISOString()
@@ -92,6 +84,11 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 	});
 
 	it('Create MoveFromRangeStart without date from node', () => {
+		const moveFromRangeStartWithoutDate = MoveRangeStart.fromNode(
+			create(
+				`<w:moveFromRangeStart xmlns:w="${NamespaceUri.w}" w:id="1" w:author="Angel" w:name="Move_from_1" />`
+			)
+		);
 		expect(moveFromRangeStartWithoutDate.props.author).toBe('Angel');
 		expect(moveFromRangeStartWithoutDate.props.date).toBe(undefined);
 		expect(moveFromRangeStartWithoutDate.props.id).toBe(1);

--- a/lib/components/track-changes/test/TextAddition.test.ts
+++ b/lib/components/track-changes/test/TextAddition.test.ts
@@ -55,7 +55,7 @@ describe('Text', () => {
 		});
 
 		expect(newAddition.props.author).toBe('Y');
-		expect(newAddition.props.date.toISOString()).toEqual(
+		expect(newAddition.props?.date?.toISOString()).toEqual(
 			date.toISOString()
 		);
 

--- a/lib/components/track-changes/test/TextDeletion.test.ts
+++ b/lib/components/track-changes/test/TextDeletion.test.ts
@@ -54,7 +54,7 @@ describe('Text', () => {
 
 		expect(newDeletion.props.author).toBe('Y');
 
-		expect(newDeletion.props.date.toISOString()).toEqual(
+		expect(newDeletion.props.date?.toISOString()).toEqual(
 			date.toISOString()
 		);
 

--- a/lib/properties/src/paragraph-properties.ts
+++ b/lib/properties/src/paragraph-properties.ts
@@ -1,4 +1,4 @@
-import { ChangeInformation } from '../../utilities/src/changes.ts';
+import type { ChangeInformation } from '../../utilities/src/changes.ts';
 import { create } from '../../utilities/src/dom.ts';
 import type { Length } from '../../utilities/src/length.ts';
 import { NamespaceUri, QNS } from '../../utilities/src/namespaces.ts';

--- a/lib/properties/src/paragraph-properties.ts
+++ b/lib/properties/src/paragraph-properties.ts
@@ -169,7 +169,7 @@ export function paragraphPropertiesFromNode(
 						"depth": ./${QNS.w}ilvl/@${QNS.w}val/number()
 					},
 					"change": ${QNS.w}pPrChange/map {
-						"id": @${QNS.w}id/string(),
+						"id": @${QNS.w}id/number(),
 						"author": @${QNS.w}author/string(),
 						"date": @${QNS.w}date/string(),
 						"_node": ./${QNS.w}pPr
@@ -193,9 +193,7 @@ export function paragraphPropertiesFromNode(
 		data.change = {
 			...data.change,
 			date: data.change.date ? new Date(data.change.date) : undefined,
-			author: data.change.author
-				? new Date(data.change.author)
-				: undefined,
+			author: data.change.author ? data.change.author : undefined,
 			...paragraphPropertiesFromNode(data.change._node),
 			_node: undefined,
 		};

--- a/lib/properties/src/paragraph-properties.ts
+++ b/lib/properties/src/paragraph-properties.ts
@@ -298,8 +298,8 @@ export async function paragraphPropertiesToNode(
 
 				if (exists($change)) then element ${QNS.w}pPrChange {
 					attribute ${QNS.w}id { $change('id') },
-					attribute ${QNS.w}author { $change('author') },
-					attribute ${QNS.w}date { $change('date') },
+					if ($change('date')) then attribute ${QNS.w}date { $change('date') } else (),
+					if ($change('author')) then attribute ${QNS.w}author { $change('author') } else (),
 					$change('node')
 				} else (),
 

--- a/lib/properties/src/paragraph-properties.ts
+++ b/lib/properties/src/paragraph-properties.ts
@@ -1,3 +1,4 @@
+import { ChangeInformation } from '../../utilities/src/changes.ts';
 import { create } from '../../utilities/src/dom.ts';
 import type { Length } from '../../utilities/src/length.ts';
 import { NamespaceUri, QNS } from '../../utilities/src/namespaces.ts';
@@ -92,13 +93,7 @@ export type ParagraphProperties = {
 	/**
 	 * Change tracking info for this paragraph.
 	 */
-	change?:
-		| null
-		| ({
-				id: number;
-				author: string;
-				date: Date;
-		  } & Omit<ParagraphProperties, 'change'>);
+	change?: null | (ChangeInformation & Omit<ParagraphProperties, 'change'>);
 	/**
 	 * Used for formatting of the `rPr` elements at the top level of a paragraph.
 	 * This is text property changes applied to the whole parent paragraph.
@@ -197,7 +192,10 @@ export function paragraphPropertiesFromNode(
 	if (data.change) {
 		data.change = {
 			...data.change,
-			date: new Date(data.change.date),
+			date: data.change.date ? new Date(data.change.date) : undefined,
+			author: data.change.author
+				? new Date(data.change.author)
+				: undefined,
 			...paragraphPropertiesFromNode(data.change._node),
 			_node: undefined,
 		};
@@ -359,8 +357,12 @@ export async function paragraphPropertiesToNode(
 			change: data.change
 				? {
 						id: data.change.id,
-						author: data.change.author,
-						date: data.change.date.toISOString(),
+						author: data.change.author
+							? data.change.author
+							: undefined,
+						date: data.change.date
+							? data.change.date.toISOString()
+							: undefined,
 						node: await paragraphPropertiesToNode(data.change),
 				  }
 				: null,

--- a/lib/properties/src/section-properties.ts
+++ b/lib/properties/src/section-properties.ts
@@ -97,8 +97,8 @@ export type SectionProperties = {
 type IntermediateProps = Omit<SectionProperties, 'change'> & {
 	change?: {
 		id: number;
-		author: string;
-		date: Date;
+		author?: string;
+		date?: Date;
 		node: Node | undefined;
 	};
 };
@@ -162,7 +162,8 @@ export function sectionPropertiesFromNode(
 	if (props.change) {
 		props.change = {
 			...props.change,
-			date: new Date(props.change.date),
+			date: props.change.date ? new Date(props.change.date) : undefined,
+			author: props.change.author ? props.change.author : undefined,
 			...sectionPropertiesFromNode(props.change.node),
 			node: undefined,
 		};
@@ -271,8 +272,8 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 			if (exists($isTitlePage)) then element ${QNS.w}titlePg { attribute ${QNS.w}val { "1" } } else (), 
 			if (exists($change)) then element ${QNS.w}sectPrChange { 
 				attribute ${QNS.w}id { $change('id') }, 
-				attribute ${QNS.w}author { $change('author') },
-				attribute ${QNS.w}date { $change('date') }, 
+				if ($change('date')) then attribute ${QNS.w}date { $change('date') } else (),
+				if ($change('author')) then attribute ${QNS.w}author { $change('author') } else (),
 				$change('node')
 			} else ()
  		}`,
@@ -303,8 +304,12 @@ export function sectionPropertiesToNode(data: SectionProperties = {}): Node {
 			change: data.change
 				? {
 						id: data.change.id,
-						author: data.change.author,
-						date: data.change.date.toISOString(),
+						author: data.change.author
+							? data.change.author
+							: undefined,
+						date: data.change.date
+							? data.change.date.toISOString()
+							: undefined,
 						node: sectionPropertiesToNode(data.change),
 				  }
 				: null,

--- a/lib/properties/src/text-properties.ts
+++ b/lib/properties/src/text-properties.ts
@@ -234,9 +234,12 @@ export function textPropertiesFromNode(node?: Node | null): TextProperties {
 		delete props.change;
 	}
 
-	if (props.move?.date) {
+	if (props.move) {
 		// Convert the date string to a Date object.
-		props.move.date = new Date(props.move.date);
+		props.move.date = props.move.date
+			? new Date(props.move.date)
+			: undefined;
+		props.move.author = props.move.author ? props.move.author : undefined;
 	}
 
 	return props as TextProperties;

--- a/lib/properties/src/text-properties.ts
+++ b/lib/properties/src/text-properties.ts
@@ -155,8 +155,8 @@ export type TextProperties = {
 type IntermediateProps = Omit<TextProperties, 'change'> & {
 	change?: {
 		id: number;
-		author: string;
-		date: Date;
+		author?: string;
+		date?: Date;
 		node: Node | undefined;
 	};
 };
@@ -225,7 +225,8 @@ export function textPropertiesFromNode(node?: Node | null): TextProperties {
 	if (props.change) {
 		props.change = {
 			...props.change,
-			date: new Date(props.change.date),
+			date: props.change.date ? new Date(props.change.date) : undefined,
+			author: props.change.author ? props.change.author : undefined,
 			...textPropertiesFromNode(props.change.node),
 			node: undefined,
 		};
@@ -233,7 +234,7 @@ export function textPropertiesFromNode(node?: Node | null): TextProperties {
 		delete props.change;
 	}
 
-	if (props.move) {
+	if (props.move?.date) {
 		// Convert the date string to a Date object.
 		props.move.date = new Date(props.move.date);
 	}
@@ -313,9 +314,9 @@ export async function textPropertiesToNode(
 				} else ()
 			} else (),
 			if (exists($change)) then element ${QNS.w}rPrChange { 
-				attribute ${QNS.w}date { $change('date') },
 				attribute ${QNS.w}id { $change('id') },
-				attribute ${QNS.w}author { $change('author') }, 
+				if ($change('date')) then attribute ${QNS.w}date { $change('date') } else (),
+				if ($change('author')) then attribute ${QNS.w}author { $change('author') } else (),
 				$change('node')
 			} else (),
 			$move
@@ -357,8 +358,12 @@ export async function textPropertiesToNode(
 			change: data.change
 				? {
 						id: data.change.id,
-						author: data.change.author,
-						date: new Date(data.change.date).toISOString(),
+						author: data.change.author
+							? data.change.author
+							: undefined,
+						date: data.change.date
+							? new Date(data.change.date).toISOString()
+							: undefined,
 						node: await textPropertiesToNode(data.change),
 				  }
 				: null,

--- a/lib/properties/test/paragraph-properties.test.ts
+++ b/lib/properties/test/paragraph-properties.test.ts
@@ -125,4 +125,84 @@ describe('Paragraph formatting', () => {
 			}
 		);
 	});
+
+	describe('Change Information properties', () => {
+		const date = new Date();
+
+		// Node with author, id and date
+		test(
+			`
+			<w:pPr ${ALL_NAMESPACE_DECLARATIONS}>
+				<w:pPrChange w:id="99" date="${date.toISOString()}" author="Inés"> 
+					<w:pPr>
+						<w:pStyle w:val="Header" />
+					</w:pPr>
+				</w:pPrChange>
+			</w:pPr>`,
+			{
+				change: {
+					id: 99,
+					date: date,
+					style: 'Header',
+					author: 'Inés',
+				},
+			}
+		);
+
+		// Node with id and date, but without author
+		test(
+			`
+            <w:pPr ${ALL_NAMESPACE_DECLARATIONS}>
+                <w:pPrChange w:id="99" date="${date.toISOString()}"> 
+                    <w:pPr>
+                        <w:pStyle w:val="Header" />
+                    </w:pPr>
+                </w:pPrChange>
+                </w:pPr>`,
+			{
+				change: {
+					id: 99,
+					date: date,
+					style: 'Header',
+				},
+			}
+		);
+
+		// Node with id and author, but without date
+		test(
+			`
+                <w:pPr ${ALL_NAMESPACE_DECLARATIONS}>
+                    <w:pPrChange w:id="99" author="Inés"> 
+                        <w:pPr>
+                            <w:pStyle w:val="Header" />
+                        </w:pPr>
+                    </w:pPrChange>
+                    </w:pPr>`,
+			{
+				change: {
+					id: 99,
+					author: 'Inés',
+					style: 'Header',
+				},
+			}
+		);
+
+		// Node with id, but without date and author
+		test(
+			`
+                <w:pPr ${ALL_NAMESPACE_DECLARATIONS}>
+                    <w:pPrChange w:id="99"> 
+                        <w:pPr>
+                            <w:pStyle w:val="Header" />
+                        </w:pPr>
+                    </w:pPrChange>
+                    </w:pPr>`,
+			{
+				change: {
+					id: 99,
+					style: 'Header',
+				},
+			}
+		);
+	});
 });

--- a/lib/properties/test/paragraph-properties.test.ts
+++ b/lib/properties/test/paragraph-properties.test.ts
@@ -133,7 +133,7 @@ describe('Paragraph formatting', () => {
 		test(
 			`
 			<w:pPr ${ALL_NAMESPACE_DECLARATIONS}>
-				<w:pPrChange w:id="99" date="${date.toISOString()}" author="Inés"> 
+				<w:pPrChange w:id="99" w:date="${date.toISOString()}" w:author="Inés"> 
 					<w:pPr>
 						<w:pStyle w:val="Header" />
 					</w:pPr>
@@ -153,7 +153,7 @@ describe('Paragraph formatting', () => {
 		test(
 			`
             <w:pPr ${ALL_NAMESPACE_DECLARATIONS}>
-                <w:pPrChange w:id="99" date="${date.toISOString()}"> 
+                <w:pPrChange w:id="99" w:date="${date.toISOString()}"> 
                     <w:pPr>
                         <w:pStyle w:val="Header" />
                     </w:pPr>
@@ -172,7 +172,7 @@ describe('Paragraph formatting', () => {
 		test(
 			`
                 <w:pPr ${ALL_NAMESPACE_DECLARATIONS}>
-                    <w:pPrChange w:id="99" author="Inés"> 
+                    <w:pPrChange w:id="99" w:author="Inés"> 
                         <w:pPr>
                             <w:pStyle w:val="Header" />
                         </w:pPr>

--- a/lib/properties/test/section-properties.test.ts
+++ b/lib/properties/test/section-properties.test.ts
@@ -60,6 +60,7 @@ describe('Section formatting', () => {
 });
 
 describe('Section property change', () => {
+	// Node with id, author and date
 	test(
 		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
 			<w:pgSz w:orient="portrait"/>
@@ -75,6 +76,67 @@ describe('Section property change', () => {
 				id: 0,
 				author: 'Gabe',
 				date: date,
+				pageWidth: twip(12240),
+				pageHeight: twip(15840),
+			},
+		}
+	);
+
+	// Node with id and date, but without author
+	test(
+		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
+				<w:pgSz w:orient="portrait"/>
+				<w:sectPrChange w:id="0" w:date="${date.toISOString()}">
+					<w:sectPr>
+						<w:pgSz w:orient="portrait" w:w="12240" w:h="15840" /> 
+					</w:sectPr>
+				</w:sectPrChange> 
+			</w:sectPr>`,
+		{
+			pageOrientation: 'portrait',
+			change: {
+				id: 0,
+				date: date,
+				pageWidth: twip(12240),
+				pageHeight: twip(15840),
+			},
+		}
+	);
+	// Node with id and author, but without date
+	test(
+		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
+			<w:pgSz w:orient="portrait"/>
+			<w:sectPrChange w:id="0" w:author="Gabe">
+				<w:sectPr>
+					<w:pgSz w:orient="portrait" w:w="12240" w:h="15840" /> 
+				</w:sectPr>
+			</w:sectPrChange> 
+		</w:sectPr>`,
+		{
+			pageOrientation: 'portrait',
+			change: {
+				id: 0,
+				author: 'Gabe',
+				pageWidth: twip(12240),
+				pageHeight: twip(15840),
+			},
+		}
+	);
+
+	// Node with id, but without date and author
+	test(
+		`<w:sectPr ${ALL_NAMESPACE_DECLARATIONS}>
+				<w:pgSz w:orient="portrait"/>
+				<w:sectPrChange w:id="0">
+					<w:sectPr>
+						<w:pgSz w:orient="portrait" w:w="12240" w:h="15840" /> 
+					</w:sectPr>
+				</w:sectPrChange> 
+			</w:sectPr>`,
+		{
+			pageOrientation: 'portrait',
+			change: {
+				id: 0,
 				pageWidth: twip(12240),
 				pageHeight: twip(15840),
 			},

--- a/lib/properties/test/text-properties.test.ts
+++ b/lib/properties/test/text-properties.test.ts
@@ -73,7 +73,7 @@ describe('Text formatting', () => {
 				date: date,
 				id: 99,
 				color: 'blue',
-				isBold: { simple: false, complex: false} 
+				isBold: { simple: false, complex: false },
 			},
 		}
 	);
@@ -90,6 +90,116 @@ describe('Complex character formatting', () => {
 			isBold: { simple: false, complex: true },
 			isItalic: { simple: false, complex: true },
 			fontSize: { simple: null, complex: hpt(23) },
+		}
+	);
+});
+
+describe('Change Information properties', () => {
+	// Node with author, id and date
+	test(
+		`
+		<w:rPr ${ALL_NAMESPACE_DECLARATIONS}>
+			<w:moveTo w:author="Gabe" w:date="${date.toISOString()}" w:id="1" /> 
+			<w:rPrChange w:author="Angel" w:date="${date.toISOString()}" w:id="99" > 
+				<w:rPr>
+					<w:color w:val="blue" /> 
+					<w:b w:val="false" /> 
+				</w:rPr>
+			</w:rPrChange>
+		</w:rPr>`,
+		{
+			move: {
+				author: 'Gabe',
+				type: 'to',
+				date: date,
+				id: 1,
+			},
+			change: {
+				author: 'Angel',
+				date: date,
+				id: 99,
+				color: 'blue',
+				isBold: { simple: false, complex: false },
+			},
+		}
+	);
+
+	// Node with id and date, but without author
+	test(
+		`
+			<w:rPr ${ALL_NAMESPACE_DECLARATIONS}>
+				<w:moveTo w:date="${date.toISOString()}" w:id="1" /> 
+				<w:rPrChange w:date="${date.toISOString()}" w:id="99" > 
+					<w:rPr>
+						<w:color w:val="blue" /> 
+						<w:b w:val="false" /> 
+					</w:rPr>
+				</w:rPrChange>
+			</w:rPr>`,
+		{
+			move: {
+				type: 'to',
+				date: date,
+				id: 1,
+			},
+			change: {
+				date: date,
+				id: 99,
+				color: 'blue',
+				isBold: { simple: false, complex: false },
+			},
+		}
+	);
+
+	// Node with id and author, but without date
+	test(
+		`
+			<w:rPr ${ALL_NAMESPACE_DECLARATIONS}>
+				<w:moveTo w:author="Gabe" w:id="1" /> 
+				<w:rPrChange w:author="Angel"  w:id="99" > 
+					<w:rPr>
+						<w:color w:val="blue" /> 
+						<w:b w:val="false" /> 
+					</w:rPr>
+				</w:rPrChange>
+			</w:rPr>`,
+		{
+			move: {
+				type: 'to',
+				author: 'Gabe',
+				id: 1,
+			},
+			change: {
+				id: 99,
+				author: 'Angel',
+				color: 'blue',
+				isBold: { simple: false, complex: false },
+			},
+		}
+	);
+
+	// Node with id, but without date and author
+	test(
+		`
+			<w:rPr ${ALL_NAMESPACE_DECLARATIONS}>
+				<w:moveTo w:id="1" /> 
+				<w:rPrChange w:id="99" > 
+					<w:rPr>
+						<w:color w:val="blue" /> 
+						<w:b w:val="false" /> 
+					</w:rPr>
+				</w:rPrChange>
+				</w:rPr>`,
+		{
+			move: {
+				type: 'to',
+				id: 1,
+			},
+			change: {
+				id: 99,
+				color: 'blue',
+				isBold: { simple: false, complex: false },
+			},
 		}
 	);
 });

--- a/lib/utilities/src/changes.ts
+++ b/lib/utilities/src/changes.ts
@@ -3,8 +3,8 @@ import { evaluateXPathToMap } from '../../utilities/src/xquery.ts';
 
 export type ChangeInformation = {
 	id: number;
-	author: string;
-	date: Date;
+	author?: string;
+	date?: Date;
 };
 
 /**
@@ -21,8 +21,8 @@ export function getChangeInformation(node?: Node | null) {
 	}
 	const props = evaluateXPathToMap<{
 		id: number;
-		author: string;
-		date: string;
+		author?: string;
+		date?: string;
 	}>(
 		`
 			map {
@@ -36,6 +36,7 @@ export function getChangeInformation(node?: Node | null) {
 
 	return {
 		...props,
-		date: new Date(props.date),
+		author: props.author ? props.author : undefined,
+		date: props.date ? new Date(props.date) : undefined,
 	} as ChangeInformation;
 }

--- a/lib/utilities/test/changes.test.ts
+++ b/lib/utilities/test/changes.test.ts
@@ -1,0 +1,88 @@
+import { expect } from 'std/expect';
+import { describe, it } from 'std/testing/bdd';
+import { Archive } from '../../classes/src/Archive.ts';
+import { ComponentContext } from '../../classes/src/Component.ts';
+import { getChangeInformation } from '../src/changes.ts';
+import { create } from '../src/dom.ts';
+import { NamespaceUri } from '../src/namespaces.ts';
+
+describe('changes', () => {
+	const date = new Date();
+
+	const emptyContext: ComponentContext = {
+		archive: new Archive(),
+		relationships: null,
+	};
+
+	it('Returns the expected changes information', () => {
+		const node = create(
+			`<w:moveTo xmlns:w="${
+				NamespaceUri.w
+			}" w:id="0" w:author="Gabe" w:date="${date.toISOString()}">
+                <w:r>
+                    <w:t xml:space="preserve">This is a paragraph</w:t>
+                </w:r>
+            </w:moveTo>`,
+			emptyContext
+		);
+
+		const changeInformation = getChangeInformation(node);
+		expect(changeInformation).toEqual({
+			id: 0,
+			author: 'Gabe',
+			date: date,
+		});
+	});
+
+	it('Returns the expected changes information from a node without date', () => {
+		const node = create(
+			`<w:moveTo xmlns:w="${NamespaceUri.w}" w:id="0" w:author="Gabe">
+                <w:r>
+                    <w:t xml:space="preserve">This is a paragraph</w:t>
+                </w:r>
+            </w:moveTo>`,
+			emptyContext
+		);
+
+		const changeInformation = getChangeInformation(node);
+		expect(changeInformation).toEqual({
+			id: 0,
+			author: 'Gabe',
+		});
+	});
+
+	it('Returns the expected changes information from a node without author', () => {
+		const node = create(
+			`<w:moveTo xmlns:w="${
+				NamespaceUri.w
+			}" w:id="0" w:date="${date.toISOString()}" >
+                <w:r>
+                    <w:t xml:space="preserve">This is a paragraph</w:t>
+                </w:r>
+            </w:moveTo>`,
+			emptyContext
+		);
+
+		const changeInformation = getChangeInformation(node);
+		expect(changeInformation).toEqual({
+			id: 0,
+			date: date,
+		});
+	});
+
+	it('Returns the expected changes information from a node without author and date', () => {
+		const node = create(
+			`<w:moveTo xmlns:w="${NamespaceUri.w}" w:id="0" >
+                <w:r>
+                    <w:t xml:space="preserve">This is a paragraph</w:t>
+                </w:r>
+            </w:moveTo>`,
+			emptyContext
+		);
+
+		const changeInformation = getChangeInformation(node);
+		expect(changeInformation).toEqual({
+			id: 0,
+		});
+	});
+});

--- a/lib/utilities/test/changes.test.ts
+++ b/lib/utilities/test/changes.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'std/expect';
 import { describe, it } from 'std/testing/bdd';
 import { Archive } from '../../classes/src/Archive.ts';
-import { ComponentContext } from '../../classes/src/Component.ts';
+import type { ComponentContext } from '../../classes/src/Component.ts';
 import { getChangeInformation } from '../src/changes.ts';
 import { create } from '../src/dom.ts';
 import { NamespaceUri } from '../src/namespaces.ts';


### PR DESCRIPTION
Apart from making author and date optional for `ChangeInformation`, this PR modifies some queries in `Move`, `MoveRangeStart` and `MoveRangeEnd` components as well as in` text-properties` and `section-properties` to adapt them in case those fields are not specified. Also I have added tests here and there.

Note that since `TextAddition/Deletion` and `RowAddition/Deletion` are going to be removed, their queries don't need to be modified. I have only made minimal changes so their tests don't fail.
