### PR TITLE
Support change tracking for table grid, table cell properties and table row properties

### DIFF
--- a/examples/track-changes/track-changes-table.tsx
+++ b/examples/track-changes/track-changes-table.tsx
@@ -43,16 +43,7 @@ const testTable = new Table(
 				id: 1,
 				author: 'Luis',
 				cellSpacing: pt(24),
-			},
-			exception: {
-				cellPadding: { top: pt(2) },
-				change: {
-					id: 22,
-					author: 'Gabe',
-					date: new Date(),
-					cellPadding: { top: pt(10) },
-				},
-			},
+			}
 		},
 		new Cell(
 			{ deletion: { author: 'Carlos', date: date, id: 2 } },

--- a/examples/track-changes/track-changes-table.tsx
+++ b/examples/track-changes/track-changes-table.tsx
@@ -44,6 +44,15 @@ const testTable = new Table(
 				author: 'Luis',
 				cellSpacing: pt(24),
 			},
+			exception: {
+				cellPadding: { top: pt(2) },
+				change: {
+					id: 22,
+					author: 'Gabe',
+					date: new Date(),
+					cellPadding: { top: pt(10) },
+				},
+			},
 		},
 		new Cell(
 			{ deletion: { author: 'Carlos', date: date, id: 2 } },

--- a/examples/track-changes/track-changes-table.tsx
+++ b/examples/track-changes/track-changes-table.tsx
@@ -11,7 +11,21 @@ const date = new Date();
 
 // Create a new table that includes a row, a row deletion, and a row addition.
 const testTable = new Table(
-	{},
+	{
+		cellPadding: {
+			top: pt(10),
+			bottom: pt(10),
+		},
+		change: {
+			id: 2,
+			author: 'Ines',
+			date: new Date(),
+			cellPadding: {
+				top: pt(24),
+				bottom: pt(24),
+			},
+		},
+	},
 	new Row(
 		{ insertion: { author: 'Luis', date: date, id: 1 } },
 		new Cell({}, new Paragraph({}, new Text({}, ' my old friend.')))
@@ -21,7 +35,14 @@ const testTable = new Table(
 		new Cell({}, new Paragraph({}, new Text({}, ' my new friend.')))
 	),
 	new Row(
-		{},
+		{
+			cellSpacing: pt(12),
+			change: {
+				id: 1,
+				author: 'Luis',
+				cellSpacing: pt(24),
+			},
+		},
 		new Cell(
 			{ deletion: { author: 'Carlos', date: date, id: 2 } },
 			new Paragraph({}, new Text({}, 'Bye!'))
@@ -38,12 +59,12 @@ const testTable = new Table(
 				borders: {
 					top: {
 						color: '0000FF',
-						width: pt(2),
+						width: pt(10),
 					},
 				},
 				shading: {
 					background: 'FF0000',
-					pattern: 'pct75',
+					pattern: 'pct5',
 				},
 				change: {
 					id: 1,
@@ -51,7 +72,14 @@ const testTable = new Table(
 					date: new Date(),
 					shading: {
 						background: '00FF00',
-						pattern: 'pct50',
+						pattern: 'pct5',
+					},
+					borders: {
+						top: {
+							color: '0000FF',
+							type: 'single',
+							width: pt(2),
+						},
 					},
 				},
 			},

--- a/examples/track-changes/track-changes-table.tsx
+++ b/examples/track-changes/track-changes-table.tsx
@@ -1,4 +1,5 @@
 /** @jsx  Docx.jsx */
+import { pt } from '../../lib/utilities/src/length.ts';
 import Docx, { Cell, Paragraph, Row, Section, Table, Text } from '../../mod.ts';
 
 // Create a new .docx file with track changes enabled.
@@ -29,6 +30,34 @@ const testTable = new Table(
 			{ insertion: { author: 'Carlos', date: date, id: 2 } },
 			new Paragraph({}, new Text({}, 'Hello!'))
 		)
+	),
+	new Row(
+		{},
+		new Cell(
+			{
+				borders: {
+					top: {
+						color: '0000FF',
+						width: pt(2),
+					},
+				},
+				shading: {
+					background: 'FF0000',
+					pattern: 'pct75',
+				},
+				change: {
+					id: 1,
+					author: 'Gabe',
+					date: new Date(),
+					shading: {
+						background: '00FF00',
+						pattern: 'pct50',
+					},
+				},
+			},
+			new Paragraph({}, new Text({}, 'Cell Property change'))
+		),
+		new Cell({}, new Paragraph({}, new Text({}, 'And unchanged.')))
 	)
 );
 

--- a/examples/track-changes/track-changes-table.tsx
+++ b/examples/track-changes/track-changes-table.tsx
@@ -16,6 +16,8 @@ const testTable = new Table(
 			top: pt(10),
 			bottom: pt(10),
 		},
+		columnWidths: [pt(48), pt(48), pt(48), pt(48)],
+		columnWidthChange: { id: 1, cols: [pt(24), pt(24), pt(24), pt(24)] },
 		change: {
 			id: 2,
 			author: 'Ines',

--- a/lib/components/document/src/Table.ts
+++ b/lib/components/document/src/Table.ts
@@ -37,6 +37,10 @@ export type TableChild = Row;
  */
 export type TableProps = TableProperties & {
 	columnWidths?: null | Length[];
+	/**
+	 * A property to specify that the table grid model has changed. This will be a tracked change in OOXML.
+	 */
+	columnWidthChange?: null | { id: number; cols: Length[] };
 };
 
 /**
@@ -70,7 +74,15 @@ export class Table extends Component<TableProps, TableChild> {
 					if (exists($columnWidths)) then element ${QNS.w}tblGrid {
 						for $columnWidth in array:flatten($columnWidths) return element ${QNS.w}gridCol {
 							attribute ${QNS.w}w { $columnWidth }
-						}
+						},
+						if (exists($columnWidthChange)) then element ${QNS.w}tblGridChange { 
+							attribute ${QNS.w}id { $columnWidthChange('id') },
+							element ${QNS.w}tblGrid { 
+								for $col in array:flatten($columnWidthChange('cols')) return element ${QNS.w}gridCol { 
+									attribute ${QNS.w}w { $col }
+								}
+							} 
+						} else ()
 					} else (),
 					$children
 				}
@@ -81,6 +93,14 @@ export class Table extends Component<TableProps, TableChild> {
 					? this.props.columnWidths.map((width) =>
 							Math.round(width.twip)
 					  )
+					: null,
+				columnWidthChange: this.props.columnWidthChange
+					? {
+							id: this.props.columnWidthChange.id,
+							cols: this.props.columnWidthChange.cols.map((col) =>
+								Math.round(col.twip)
+							),
+					  }
 					: null,
 				children: await this.childrenToNode(ancestry),
 			}
@@ -110,6 +130,10 @@ export class Table extends Component<TableProps, TableChild> {
 					"columnWidths": array {
 						./${QNS.w}tblGrid/${QNS.w}gridCol/@${QNS.w}w/number()
 					},
+					"columnWidthChange": ./${QNS.w}tblGrid/${QNS.w}tblGridChange/map { 
+						"id": @${QNS.w}id/number(),
+						"cols": array { ./${QNS.w}tblGrid/${QNS.w}gridCol/@${QNS.w}w/number() }
+					}, 
 					"children": array{ ./(${QNS.w}tr) }
 				}
 			`,

--- a/lib/components/document/src/Table.ts
+++ b/lib/components/document/src/Table.ts
@@ -16,6 +16,7 @@ import {
 	tablePropertiesFromNode,
 	tablePropertiesToNode,
 } from '../../../properties/src/table-properties.ts';
+import type { ChangeInformation } from '../../../utilities/src/changes.ts';
 import {
 	createChildComponentsFromNodes,
 	registerComponent,
@@ -40,7 +41,9 @@ export type TableProps = TableProperties & {
 	/**
 	 * A property to specify that the table grid model has changed. This will be a tracked change in OOXML.
 	 */
-	columnWidthChange?: null | { id: number; cols: Length[] };
+	columnWidthChange?:
+		| null
+		| (Omit<ChangeInformation, 'author' | 'date'> & { cols: Length[] });
 };
 
 /**

--- a/lib/components/document/src/Table.ts
+++ b/lib/components/document/src/Table.ts
@@ -134,7 +134,7 @@ export class Table extends Component<TableProps, TableChild> {
 						"id": @${QNS.w}id/number(),
 						"cols": array { ./${QNS.w}tblGrid/${QNS.w}gridCol/@${QNS.w}w/number() }
 					}, 
-					"children": array{ ./(${QNS.w}tr) }
+					"children": array { ./(${QNS.w}tr) }
 				}
 			`,
 			node

--- a/lib/components/document/src/Table.ts
+++ b/lib/components/document/src/Table.ts
@@ -123,6 +123,7 @@ export class Table extends Component<TableProps, TableChild> {
 			tblpr: Node;
 			children: Node[];
 			columnWidths: number[];
+			columnWidthChange: { id: number; cols: number[] };
 		}>(
 			`
 				map {
@@ -141,10 +142,18 @@ export class Table extends Component<TableProps, TableChild> {
 		);
 		return new Table(
 			{
+				...tablePropertiesFromNode(tblpr),
 				columnWidths: props.columnWidths.map((size: number) =>
 					twip(size)
 				),
-				...tablePropertiesFromNode(tblpr),
+				columnWidthChange: props.columnWidthChange
+					? {
+							id: props.columnWidthChange.id,
+							cols: props.columnWidthChange.cols.map(
+								(size: number) => twip(size)
+							),
+					  }
+					: null,
 			},
 			...createChildComponentsFromNodes<TableChild>(
 				this.children,

--- a/lib/components/document/test/Table.test.ts
+++ b/lib/components/document/test/Table.test.ts
@@ -5,6 +5,7 @@ import { describe, it } from 'std/testing/bdd';
 import { Archive } from '../../../classes/src/Archive.ts';
 import type { ComponentContext } from '../../../classes/src/Component.ts';
 import { create } from '../../../utilities/src/dom.ts';
+import { twip } from '../../../utilities/src/length.ts';
 import { NamespaceUri } from '../../../utilities/src/namespaces.ts';
 import { Table } from '../src/Table.ts';
 
@@ -24,6 +25,20 @@ describe('Table', () => {
 	const table = Table.fromNode(
 		create(`
 			<w:tbl xmlns:w="${NamespaceUri.w}">
+				<w:tblGrid>
+					<w:gridCol w:w="960"/>
+					<w:gridCol w:w="960"/>
+					<w:gridCol w:w="960"/>
+					<w:gridCol w:w="960"/>
+					<w:tblGridChange w:id="1">
+						<w:tblGrid>
+							<w:gridCol w:w="480"/>
+							<w:gridCol w:w="480"/>
+							<w:gridCol w:w="480"/>
+							<w:gridCol w:w="480"/>
+						</w:tblGrid>
+					</w:tblGridChange>
+				</w:tblGrid>
 				<w:tr>
 					<w:tc>
 						<w:tcPr>
@@ -136,6 +151,23 @@ describe('Table', () => {
 		`),
 		emptyContext
 	);
+	it('Table grid has been defined', () => {
+		expect(table.props.columnWidths).toEqual([
+			twip(960),
+			twip(960),
+			twip(960),
+			twip(960),
+		]);
+	});
+
+	it('Table grid has been changed', () => {
+		expect(table.props.columnWidthChange?.cols).toEqual([
+			twip(480),
+			twip(480),
+			twip(480),
+			twip(480),
+		]);
+	});
 
 	it('Row 0 has the correct amount of cells', () =>
 		expect(table.children[0].children).toHaveLength(2));

--- a/lib/properties/src/table-cell-properties.ts
+++ b/lib/properties/src/table-cell-properties.ts
@@ -2,6 +2,7 @@ import { CellDeletion } from '../../components/track-changes/src/CellDeletion.ts
 import { CellInsertion } from '../../components/track-changes/src/CellInsertion.ts';
 import type { DeletionProps } from '../../components/track-changes/src/Deletion.ts';
 import type { InsertionProps } from '../../components/track-changes/src/Insertion.ts';
+import type { ChangeInformation } from '../../utilities/src/changes.ts';
 import { create } from '../../utilities/src/dom.ts';
 import type { Length } from '../../utilities/src/length.ts';
 import { NamespaceUri, QNS } from '../../utilities/src/namespaces.ts';
@@ -64,6 +65,14 @@ export type TableCellProperties = {
 	 * Read more here: https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_cellDel_topic_ID0E5IOV.html
 	 */
 	deletion?: null | DeletionProps;
+	/**
+	 * A property used to indicate when the properties of a table cell should appear as a
+	 * tracked change when the document is opened in Word.
+	 *
+	 * Read more here: https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_tcPrChange_topic_ID0EEKVW.html
+	 *
+	 */
+	change?: null | (ChangeInformation & Omit<TableCellProperties, 'change'>);
 };
 
 export function tableCellPropertiesFromNode(
@@ -121,6 +130,12 @@ export function tableCellPropertiesFromNode(
 						"id": @${QNS.w}id/number(), 
 						"author": @${QNS.w}author/string(), 
 						"date": @${QNS.w}date/string()
+					},
+					"change": ./${QNS.w}tcPrChange/map { 
+						"id": @${QNS.w}id/number(),
+						"author": @${QNS.w}author/string(),
+						"date": @${QNS.w}date/string(), 
+						"node": ./${QNS.w}tcPr
 					}
 				}
 				`,
@@ -189,6 +204,12 @@ export function tableCellPropertiesToNode(
 			if (exists($verticalAlignment)) then element ${QNS.w}vAlign {
 				attribute ${QNS.w}val { $verticalAlignment }
 			} else (),
+			if (exists($change)) then element ${QNS.w}tcPrChange { 
+				attribute ${QNS.w}id { $change('id') },
+				if ($change('author')) then attribute ${QNS.w}author { $change('author') } else (),
+				if ($change('date')) then attribute ${QNS.w}date { $change('date')} else (),
+				$change('node')
+			} else (),
 			$insertion,
 			$deletion
 		}`,
@@ -212,6 +233,18 @@ export function tableCellPropertiesToNode(
 				  }
 				: null,
 			verticalAlignment: tcpr.verticalAlignment || null,
+			change: tcpr.change
+				? {
+						id: tcpr.change.id,
+						author: tcpr.change.author
+							? tcpr.change.author
+							: undefined,
+						date: tcpr.change.date
+							? new Date(tcpr.change.date).toISOString()
+							: undefined,
+						node: tableCellPropertiesToNode(tcpr.change, false),
+				  }
+				: null,
 			insertion: tcpr.insertion
 				? new CellInsertion(tcpr.insertion).toNode()
 				: null,

--- a/lib/properties/src/table-cell-properties.ts
+++ b/lib/properties/src/table-cell-properties.ts
@@ -179,8 +179,6 @@ export function tableCellPropertiesFromNode(
 			: undefined;
 	}
 
-	console.log('WIDTH: ', props.width);
-
 	return props as TableCellProperties;
 }
 

--- a/lib/properties/src/table-cell-properties.ts
+++ b/lib/properties/src/table-cell-properties.ts
@@ -75,11 +75,15 @@ export type TableCellProperties = {
 	change?: null | (ChangeInformation & Omit<TableCellProperties, 'change'>);
 };
 
+type IntermediateProps = Omit<TableCellProperties, 'change'> & {
+	change?: ChangeInformation & { node: Node | undefined };
+};
+
 export function tableCellPropertiesFromNode(
 	node?: Node | null
 ): TableCellProperties {
 	const props = node
-		? evaluateXPathToMap<TableCellProperties>(
+		? evaluateXPathToMap<IntermediateProps>(
 				`
 				let $colStart := docxml:cell-column(.)
 
@@ -103,6 +107,9 @@ export function tableCellPropertiesFromNode(
 					else count(../../../${QNS.w}tr)
 
 				return map {
+					"width": if (${QNS.w}tcW)
+						then docxml:length(${QNS.w}tcW/@${QNS.w}w, 'twip') 
+						else (),
 					"colSpan": if (./${QNS.w}gridSpan)
 						then ./${QNS.w}gridSpan/@${QNS.w}val/number()
 						else 1,
@@ -143,6 +150,16 @@ export function tableCellPropertiesFromNode(
 		  )
 		: {};
 
+	if (props.change) {
+		props.change = {
+			...props.change,
+			id: props.change.id,
+			date: props.change.date ? new Date(props.change.date) : undefined,
+			...tableCellPropertiesFromNode(props.change.node),
+			node: undefined,
+		};
+	}
+
 	// Convert the date string to a Date object.
 	if (props.insertion) {
 		props.insertion.date = props.insertion.date
@@ -162,7 +179,9 @@ export function tableCellPropertiesFromNode(
 			: undefined;
 	}
 
-	return props;
+	console.log('WIDTH: ', props.width);
+
+	return props as TableCellProperties;
 }
 
 export function tableCellPropertiesToNode(
@@ -175,7 +194,7 @@ export function tableCellPropertiesToNode(
 
 	return create(
 		`element ${QNS.w}tcPr {
-			if ($width) then element ${QNS.w}tcW {
+			if (exists($width)) then element ${QNS.w}tcW {
 				attribute ${QNS.w}w { $width },
 				attribute ${QNS.w}type { "dxa" }
 			} else (),
@@ -242,7 +261,7 @@ export function tableCellPropertiesToNode(
 						date: tcpr.change.date
 							? new Date(tcpr.change.date).toISOString()
 							: undefined,
-						node: tableCellPropertiesToNode(tcpr.change, false),
+						node: tableCellPropertiesToNode(tcpr.change, true),
 				  }
 				: null,
 			insertion: tcpr.insertion

--- a/lib/properties/src/table-properties.ts
+++ b/lib/properties/src/table-properties.ts
@@ -1,3 +1,4 @@
+import { ChangeInformation } from '@fontoxml/docxml';
 import { create } from '../../utilities/src/dom.ts';
 import type { Length } from '../../utilities/src/length.ts';
 import { NamespaceUri, QNS } from '../../utilities/src/namespaces.ts';
@@ -78,6 +79,7 @@ export type TableProperties = {
 		insideH?: null | Border<LineBorderType | ArtBorderType>;
 		insideV?: null | Border<LineBorderType | ArtBorderType>;
 	};
+	change?: null | (ChangeInformation & Omit<TableProperties, 'change'>);
 };
 
 export function tablePropertiesFromNode(node: Node | null): TableProperties {
@@ -115,7 +117,13 @@ export function tablePropertiesFromNode(node: Node | null): TableProperties {
 						"length": ./@${QNS.w}w/string(),
 						"unit": ./@${QNS.w}type/string()
 					},
-					"strictColumnWidths": boolean(./${QNS.w}tblLayout/@${QNS.w}type = "fixed")
+					"strictColumnWidths": boolean(./${QNS.w}tblLayout/@${QNS.w}type = "fixed"), 
+					"change": ./${QNS.w}trPrChange/map { 
+						"id": @${QNS.w}id/number(),
+						"author": @${QNS.w}author/string(),
+						"date": @${QNS.w}date/string(),
+						"node": ./${QNS.w}trPr
+					}
 				}`,
 				node
 		  )
@@ -185,7 +193,13 @@ export function tablePropertiesToNode(tblpr: TableProperties = {}): Node {
 			} else (),
 			if ($strictColumnWidths) then element ${QNS.w}tblLayout {
 				attribute ${QNS.w}type { "fixed" }
-			} else ()
+			} else (),
+			if (exists($change)) then element ${QNS.w}tblPrChange { 
+				attribute ${QNS.w}id { $change('id') },
+				if (exists($change('author'))) then attribute ${QNS.w}author { $change('author') } else (),
+				if (exists($change('date'))) then attribute ${QNS.w}date { $change('date') } else (),
+				$change('node')
+			} else () 
 		}`,
 		{
 			style: tblpr.style || null,
@@ -216,6 +230,14 @@ export function tablePropertiesToNode(tblpr: TableProperties = {}): Node {
 			columnBandingSize: tblpr.columnBandingSize || null,
 			rowBandingSize: tblpr.rowBandingSize || null,
 			strictColumnWidths: tblpr.strictColumnWidths || false,
+			change: tblpr.change
+				? {
+						date: tblpr.change.date
+							? new Date(tblpr.change.date).toISOString()
+							: undefined,
+						...tblpr.change,
+				  }
+				: null,
 		}
 	);
 }

--- a/lib/properties/src/table-properties.ts
+++ b/lib/properties/src/table-properties.ts
@@ -1,4 +1,5 @@
-import { ChangeInformation } from '@fontoxml/docxml';
+import type { TableProps } from '../../components/document/src/Table.ts';
+import type { ChangeInformation } from '../../utilities/src/changes.ts';
 import { create } from '../../utilities/src/dom.ts';
 import type { Length } from '../../utilities/src/length.ts';
 import { NamespaceUri, QNS } from '../../utilities/src/namespaces.ts';
@@ -132,7 +133,7 @@ export function tablePropertiesFromNode(node: Node | null): TableProperties {
 	return properties;
 }
 
-export function tablePropertiesToNode(tblpr: TableProperties = {}): Node {
+export function tablePropertiesToNode(tblpr: TableProps = {}): Node {
 	return create(
 		`element ${QNS.w}tblPr {
 			if ($style) then element ${QNS.w}tblStyle {

--- a/lib/properties/src/table-properties.ts
+++ b/lib/properties/src/table-properties.ts
@@ -83,9 +83,13 @@ export type TableProperties = {
 	change?: null | (ChangeInformation & Omit<TableProperties, 'change'>);
 };
 
+type IntermediateProps = Omit<TableProperties, 'change'> & {
+	change?: ChangeInformation & { node: Node | null };
+};
+
 export function tablePropertiesFromNode(node: Node | null): TableProperties {
 	const properties = node
-		? evaluateXPathToMap<TableProperties>(
+		? evaluateXPathToMap<IntermediateProps>(
 				`map {
 					"style": ./${QNS.w}tblStyle/@${QNS.w}val/string(),
 					"activeConditions": ./${QNS.w}tblLook/map {
@@ -119,18 +123,29 @@ export function tablePropertiesFromNode(node: Node | null): TableProperties {
 						"unit": ./@${QNS.w}type/string()
 					},
 					"strictColumnWidths": boolean(./${QNS.w}tblLayout/@${QNS.w}type = "fixed"), 
-					"change": ./${QNS.w}trPrChange/map { 
+					"change": ./${QNS.w}tblPrChange/map { 
 						"id": @${QNS.w}id/number(),
 						"author": @${QNS.w}author/string(),
 						"date": @${QNS.w}date/string(),
-						"node": ./${QNS.w}trPr
+						"node": ./${QNS.w}tblPr
 					}
 				}`,
 				node
 		  )
 		: {};
+	if (properties.change) {
+		properties.change = {
+			...properties.change,
+			id: properties.change.id,
+			date: properties.change.date
+				? new Date(properties.change.date)
+				: undefined,
+			...tablePropertiesFromNode(properties.change.node),
+			node: null,
+		};
+	}
 
-	return properties;
+	return properties as TableProperties;
 }
 
 export function tablePropertiesToNode(tblpr: TableProps = {}): Node {
@@ -233,10 +248,14 @@ export function tablePropertiesToNode(tblpr: TableProps = {}): Node {
 			strictColumnWidths: tblpr.strictColumnWidths || false,
 			change: tblpr.change
 				? {
+						id: tblpr.change.id,
+						author: tblpr.change.author
+							? tblpr.change.author
+							: undefined,
 						date: tblpr.change.date
 							? new Date(tblpr.change.date).toISOString()
 							: undefined,
-						...tblpr.change,
+						node: tablePropertiesToNode(tblpr.change),
 				  }
 				: null,
 		}

--- a/lib/properties/src/table-row-properties.ts
+++ b/lib/properties/src/table-row-properties.ts
@@ -1,9 +1,9 @@
-import type { ChangeInformation } from '@fontoxml/docxml';
 import { Deletion } from '../../components/track-changes/src/Deletion.ts';
 import {
 	Insertion,
 	type InsertionProps,
 } from '../../components/track-changes/src/Insertion.ts';
+import type { ChangeInformation } from '../../utilities/src/changes.ts';
 import { create } from '../../utilities/src/dom.ts';
 import type { Length } from '../../utilities/src/length.ts';
 import { QNS } from '../../utilities/src/namespaces.ts';

--- a/lib/properties/src/table-row-properties.ts
+++ b/lib/properties/src/table-row-properties.ts
@@ -1,4 +1,8 @@
 import type { ChangeInformation } from '@fontoxml/docxml';
+import {
+	hasUncaughtExceptionCaptureCallback,
+	prependOnceListener,
+} from 'node:process';
 import { Deletion } from '../../components/track-changes/src/Deletion.ts';
 import {
 	Insertion,
@@ -8,6 +12,7 @@ import { create } from '../../utilities/src/dom.ts';
 import type { Length } from '../../utilities/src/length.ts';
 import { QNS } from '../../utilities/src/namespaces.ts';
 import { evaluateXPathToMap } from '../../utilities/src/xquery.ts';
+import { type TableProperties } from './table-properties.ts';
 
 export type TableRowProperties = {
 	/**
@@ -27,10 +32,28 @@ export type TableRowProperties = {
 	 */
 	cellSpacing?: null | Length;
 	/**
-	 * A property used to indicate when a table property has changed. This will appear as a tracked
+	 * A property used to indicate when a table row property has changed. This will appear as a tracked
 	 * change in Word's track changes feature.
 	 */
 	change?: null | (ChangeInformation & Omit<TableRowProperties, 'change'>);
+	/**
+	 * A property used to indicate that this table row should be excepted from the specified
+	 * table-level properties.
+	 *
+	 * Read more: https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_tblPrEx_topic_ID0E1GNR.html#topic_ID0E1GNR
+	 */
+	exception?:
+		| null
+		| (Omit<TableProperties, 'change'> & {
+				/**
+				 * A property used to indicate that there have been changes made to the exceptions.
+				 *
+				 * Read more here: https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_tblPrExChange_topic_ID0EK1UW.html
+				 */
+				change?:
+					| null
+					| (ChangeInformation & Omit<TableProperties, 'change'>);
+		  });
 	/**
 	 * A property used to indicate when a row has been inserted.
 	 *
@@ -49,11 +72,25 @@ export type TableRowProperties = {
 	deletion?: null | InsertionProps;
 };
 
+type IntermediateTableRowProps = Omit<TableRowProperties, 'exception'> & {
+	exception?:
+		| null
+		| (Omit<TableRowProperties, 'change' | 'exception'> & {
+				change?: {
+					id: number;
+					author?: string;
+					date?: Date;
+					node: Node | undefined;
+				};
+				node: Node | undefined;
+		  });
+};
+
 export function tableRowPropertiesFromNode(
 	node?: Node | null
 ): TableRowProperties {
 	const props = node
-		? evaluateXPathToMap<TableRowProperties>(
+		? evaluateXPathToMap<IntermediateTableRowProps>(
 				`map {
 					"isHeaderRow": docxml:ct-on-off(./${QNS.w}tblHeader),
 					"isUnsplittable": docxml:ct-on-off(./${QNS.w}cantSplit),
@@ -63,6 +100,15 @@ export function tableRowPropertiesFromNode(
 						"author": @${QNS.w}author/string(),
 						"date": @${QNS.w}date/string(),
 						"node": ./${QNS.w}trPr
+					},
+					"exception": ./${QNS.w}tblPrEx/map { 
+						"node": ./${QNS.w}*[not(self::${QNS.w}tblPrExChange)],
+						"change": ./${QNS.w}tblPrExChange/map {
+							"id": @${QNS.w}id/number(), 
+							"author": @${QNS.w}author/string(), 
+							"date": @${QNS.w}/date/string(), 
+							"node": ./${QNS.w}tblPrEx
+						}
 					},
 					"insertion": ./${QNS.w}ins/map {
 						"id": @${QNS.w}id/number(), 
@@ -94,6 +140,26 @@ export function tableRowPropertiesFromNode(
 			: undefined;
 	}
 
+	if (props.exception) {
+		props.exception = {
+			...tableRowPropertiesFromNode(props.exception.node),
+			change: props.exception.change
+				? {
+						date: props.exception.change.date
+							? new Date(props.exception.change.date)
+							: undefined,
+						id: props.exception.change.id,
+						author: props.exception.change.author,
+						...tableRowPropertiesFromNode(
+							props.exception.change.node
+						),
+						node: undefined,
+				  }
+				: undefined,
+			node: undefined,
+		};
+	}
+
 	if (props.deletion) {
 		props.deletion.date = props.deletion.date
 			? new Date(props.deletion.date)
@@ -103,7 +169,7 @@ export function tableRowPropertiesFromNode(
 			: undefined;
 	}
 
-	return props;
+	return props as TableRowProperties;
 }
 
 export async function tableRowPropertiesToNode(
@@ -126,6 +192,17 @@ export async function tableRowPropertiesToNode(
 				if ($change('date')) then attribute ${QNS.w}date { $change('date') } else (),
 				$change('node') 
 			} else (), 
+			if (exists($exception)) then element ${QNS.w}tblPrEx { 
+				if (exists($exception('change'))) then element ${QNS.w}tblPrExChange { 
+					attribute ${QNS.w}id { $exception('change')('id')}, 
+					attribute ${QNS.w}author { $exception('change')('author')}, 
+					attribute ${QNS.w}date { $exception('change')('date')}, 
+					element ${QNS.w}tblPrEx { 
+						array:flatten($exception('change')('node'))
+					}
+				} else (),
+				$exception('node')
+			} else (),
 			$insertion,
 			$deletion
 		}`,
@@ -143,6 +220,25 @@ export async function tableRowPropertiesToNode(
 							? new Date(trpr.change.date).toISOString()
 							: undefined,
 						node: await tableRowPropertiesToNode(trpr.change),
+				  }
+				: null,
+			exception: trpr.exception
+				? {
+						node: await tableRowPropertiesToNode(trpr.exception),
+						change: trpr.exception.change
+							? {
+									id: trpr.exception.change.id,
+									author: trpr.exception.change.author
+										? trpr.exception.change.author
+										: undefined,
+									date: trpr.exception.change.date
+										? trpr.exception.change.date.toISOString()
+										: undefined,
+									node: await tableRowPropertiesToNode(
+										trpr.exception.change
+									),
+							  }
+							: null,
 				  }
 				: null,
 			insertion: trpr.insertion

--- a/lib/properties/src/table-row-properties.ts
+++ b/lib/properties/src/table-row-properties.ts
@@ -1,8 +1,4 @@
 import type { ChangeInformation } from '@fontoxml/docxml';
-import {
-	hasUncaughtExceptionCaptureCallback,
-	prependOnceListener,
-} from 'node:process';
 import { Deletion } from '../../components/track-changes/src/Deletion.ts';
 import {
 	Insertion,
@@ -12,7 +8,6 @@ import { create } from '../../utilities/src/dom.ts';
 import type { Length } from '../../utilities/src/length.ts';
 import { QNS } from '../../utilities/src/namespaces.ts';
 import { evaluateXPathToMap } from '../../utilities/src/xquery.ts';
-import { type TableProperties } from './table-properties.ts';
 
 export type TableRowProperties = {
 	/**
@@ -37,24 +32,6 @@ export type TableRowProperties = {
 	 */
 	change?: null | (ChangeInformation & Omit<TableRowProperties, 'change'>);
 	/**
-	 * A property used to indicate that this table row should be excepted from the specified
-	 * table-level properties.
-	 *
-	 * Read more: https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_tblPrEx_topic_ID0E1GNR.html#topic_ID0E1GNR
-	 */
-	exception?:
-		| null
-		| (Omit<TableProperties, 'change'> & {
-				/**
-				 * A property used to indicate that there have been changes made to the exceptions.
-				 *
-				 * Read more here: https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_tblPrExChange_topic_ID0EK1UW.html
-				 */
-				change?:
-					| null
-					| (ChangeInformation & Omit<TableProperties, 'change'>);
-		  });
-	/**
 	 * A property used to indicate when a row has been inserted.
 	 *
 	 * If present, the containing row element will appear as a track-change inserted row.
@@ -72,25 +49,19 @@ export type TableRowProperties = {
 	deletion?: null | InsertionProps;
 };
 
-type IntermediateTableRowProps = Omit<TableRowProperties, 'exception'> & {
-	exception?:
-		| null
-		| (Omit<TableRowProperties, 'change' | 'exception'> & {
-				change?: {
-					id: number;
-					author?: string;
-					date?: Date;
-					node: Node | undefined;
-				};
-				node: Node | undefined;
-		  });
+type IntermediateProps = Omit<TableRowProperties, 'change'> & {
+	change?: ChangeInformation & { node: Node | undefined };
 };
 
 export function tableRowPropertiesFromNode(
 	node?: Node | null
 ): TableRowProperties {
+	if (!node) {
+		return {};
+	}
+
 	const props = node
-		? evaluateXPathToMap<IntermediateTableRowProps>(
+		? evaluateXPathToMap<IntermediateProps>(
 				`map {
 					"isHeaderRow": docxml:ct-on-off(./${QNS.w}tblHeader),
 					"isUnsplittable": docxml:ct-on-off(./${QNS.w}cantSplit),
@@ -100,15 +71,6 @@ export function tableRowPropertiesFromNode(
 						"author": @${QNS.w}author/string(),
 						"date": @${QNS.w}date/string(),
 						"node": ./${QNS.w}trPr
-					},
-					"exception": ./${QNS.w}tblPrEx/map { 
-						"node": ./${QNS.w}*[not(self::${QNS.w}tblPrExChange)],
-						"change": ./${QNS.w}tblPrExChange/map {
-							"id": @${QNS.w}id/number(), 
-							"author": @${QNS.w}author/string(), 
-							"date": @${QNS.w}/date/string(), 
-							"node": ./${QNS.w}tblPrEx
-						}
 					},
 					"insertion": ./${QNS.w}ins/map {
 						"id": @${QNS.w}id/number(), 
@@ -122,13 +84,17 @@ export function tableRowPropertiesFromNode(
 					}
 				}`,
 				node
-		  )
+		  ) || {}
 		: {};
 	// Convert the date string to a Date object.
 	if (props.change) {
-		props.change.date = props.change.date
-			? new Date(props.change.date)
-			: undefined;
+		props.change = {
+			...props.change,
+			id: props.change.id,
+			date: props.change.date ? new Date(props.change.date) : undefined,
+			...tableRowPropertiesFromNode(props.change.node),
+			node: undefined,
+		};
 	}
 
 	if (props.insertion) {
@@ -138,26 +104,6 @@ export function tableRowPropertiesFromNode(
 		props.insertion.author = props.insertion.author
 			? props.insertion.author
 			: undefined;
-	}
-
-	if (props.exception) {
-		props.exception = {
-			...tableRowPropertiesFromNode(props.exception.node),
-			change: props.exception.change
-				? {
-						date: props.exception.change.date
-							? new Date(props.exception.change.date)
-							: undefined,
-						id: props.exception.change.id,
-						author: props.exception.change.author,
-						...tableRowPropertiesFromNode(
-							props.exception.change.node
-						),
-						node: undefined,
-				  }
-				: undefined,
-			node: undefined,
-		};
 	}
 
 	if (props.deletion) {
@@ -191,17 +137,6 @@ export async function tableRowPropertiesToNode(
 				if ($change('author')) then attribute ${QNS.w}author { $change('author') } else (), 
 				if ($change('date')) then attribute ${QNS.w}date { $change('date') } else (),
 				$change('node') 
-			} else (), 
-			if (exists($exception)) then element ${QNS.w}tblPrEx { 
-				if (exists($exception('change'))) then element ${QNS.w}tblPrExChange { 
-					attribute ${QNS.w}id { $exception('change')('id')}, 
-					attribute ${QNS.w}author { $exception('change')('author')}, 
-					attribute ${QNS.w}date { $exception('change')('date')}, 
-					element ${QNS.w}tblPrEx { 
-						array:flatten($exception('change')('node'))
-					}
-				} else (),
-				$exception('node')
 			} else (),
 			$insertion,
 			$deletion
@@ -220,25 +155,6 @@ export async function tableRowPropertiesToNode(
 							? new Date(trpr.change.date).toISOString()
 							: undefined,
 						node: await tableRowPropertiesToNode(trpr.change),
-				  }
-				: null,
-			exception: trpr.exception
-				? {
-						node: await tableRowPropertiesToNode(trpr.exception),
-						change: trpr.exception.change
-							? {
-									id: trpr.exception.change.id,
-									author: trpr.exception.change.author
-										? trpr.exception.change.author
-										: undefined,
-									date: trpr.exception.change.date
-										? trpr.exception.change.date.toISOString()
-										: undefined,
-									node: await tableRowPropertiesToNode(
-										trpr.exception.change
-									),
-							  }
-							: null,
 				  }
 				: null,
 			insertion: trpr.insertion

--- a/lib/properties/src/table-row-properties.ts
+++ b/lib/properties/src/table-row-properties.ts
@@ -1,3 +1,4 @@
+import type { ChangeInformation } from '@fontoxml/docxml';
 import { Deletion } from '../../components/track-changes/src/Deletion.ts';
 import {
 	Insertion,
@@ -26,6 +27,11 @@ export type TableRowProperties = {
 	 */
 	cellSpacing?: null | Length;
 	/**
+	 * A property used to indicate when a table property has changed. This will appear as a tracked
+	 * change in Word's track changes feature.
+	 */
+	change?: null | (ChangeInformation & Omit<TableRowProperties, 'change'>);
+	/**
 	 * A property used to indicate when a row has been inserted.
 	 *
 	 * If present, the containing row element will appear as a track-change inserted row.
@@ -52,6 +58,12 @@ export function tableRowPropertiesFromNode(
 					"isHeaderRow": docxml:ct-on-off(./${QNS.w}tblHeader),
 					"isUnsplittable": docxml:ct-on-off(./${QNS.w}cantSplit),
 					"cellSpacing": docxml:length(${QNS.w}tblCellSpacing[not(@${QNS.w}type = 'nil')]/@${QNS.w}w, 'twip'),
+					"change": ./${QNS.w}trPrChange/map {
+						"id": @${QNS.w}id/number(),
+						"author": @${QNS.w}author/string(),
+						"date": @${QNS.w}date/string(),
+						"node": ./${QNS.w}trPr
+					},
 					"insertion": ./${QNS.w}ins/map {
 						"id": @${QNS.w}id/number(), 
 						"author": @${QNS.w}author/string(), 
@@ -66,8 +78,13 @@ export function tableRowPropertiesFromNode(
 				node
 		  )
 		: {};
-
 	// Convert the date string to a Date object.
+	if (props.change) {
+		props.change.date = props.change.date
+			? new Date(props.change.date)
+			: undefined;
+	}
+
 	if (props.insertion) {
 		props.insertion.date = props.insertion.date
 			? new Date(props.insertion.date)
@@ -103,6 +120,12 @@ export async function tableRowPropertiesToNode(
 				attribute ${QNS.w}w { round($cellSpacing('twip')) },
 				attribute ${QNS.w}type { "dxa" }
 			} else (),
+			if (exists($change)) then element ${QNS.w}trPrChange { 
+				attribute ${QNS.w}id { $change('id') }, 
+				if ($change('author')) then attribute ${QNS.w}author { $change('author') } else (), 
+				if ($change('date')) then attribute ${QNS.w}date { $change('date') } else (),
+				$change('node') 
+			} else (), 
 			$insertion,
 			$deletion
 		}`,
@@ -110,6 +133,18 @@ export async function tableRowPropertiesToNode(
 			isHeaderRow: trpr.isHeaderRow || false,
 			isUnsplittable: trpr.isUnsplittable || false,
 			cellSpacing: trpr.cellSpacing || null,
+			change: trpr.change
+				? {
+						id: trpr.change.id,
+						author: trpr.change.author
+							? trpr.change.author
+							: undefined,
+						date: trpr.change.date
+							? new Date(trpr.change.date).toISOString()
+							: undefined,
+						node: await tableRowPropertiesToNode(trpr.change),
+				  }
+				: null,
 			insertion: trpr.insertion
 				? await new Insertion(trpr.insertion).toNode([])
 				: null,

--- a/lib/properties/test/table-cell-properties.test.ts
+++ b/lib/properties/test/table-cell-properties.test.ts
@@ -1,7 +1,7 @@
 import { describe } from 'std/testing/bdd';
 
 import { parse } from '../../utilities/src/dom.ts';
-import { opt } from '../../utilities/src/length.ts';
+import { opt, twip } from '../../utilities/src/length.ts';
 import { ALL_NAMESPACE_DECLARATIONS } from '../../utilities/src/namespaces.ts';
 import { createXmlRoundRobinTest } from '../../utilities/src/tests.ts';
 import { evaluateXPathToFirstNode } from '../../utilities/src/xquery.ts';
@@ -15,6 +15,8 @@ const test = createXmlRoundRobinTest<TableCellProperties>(
 	tableCellPropertiesFromNode,
 	(n: TableCellProperties) => tableCellPropertiesToNode(n, false)
 );
+
+const date = new Date();
 
 describe('Table cell formatting', () => {
 	const dom = parse(`<w:tbl ${ALL_NAMESPACE_DECLARATIONS}>
@@ -40,6 +42,11 @@ describe('Table cell formatting', () => {
 						<w:end w:val="double" w:sz="24" w:space="0" w:color="FF0000"/>
 						<w:tl2br w:val="double" w:sz="24" w:space="0" w:color="FF0000"/>
 					</w:tcBorders>
+					<w:tcPrChange w:id="8" w:author="Eva" w:date="${date}">
+						<w:tcPr>
+							<w:tcW w:w="3402" w:type="dxa" />
+						</w:tcPr>
+					</w:tcPrChange>
 				</w:tcPr>
 				<w:p>
 					<w:pPr />
@@ -131,6 +138,12 @@ describe('Table cell formatting', () => {
 				tr2bl: null,
 				insideH: null,
 				insideV: null,
+			},
+			change: {
+				id: 8,
+				author: 'Eva',
+				date: date,
+				width: twip(3402),
 			},
 		}
 	);

--- a/lib/properties/test/table-properties.test.ts
+++ b/lib/properties/test/table-properties.test.ts
@@ -112,11 +112,11 @@ describe('Table formatting', () => {
 	describe('Legacy schema for cellPadding', () => {
 		test(
 			`<w:tblPr ${ALL_NAMESPACE_DECLARATIONS}>
-					<w:tblCellMar>
-						<w:left w:w="432" w:type="dxa" />
-						<w:right w:w="144" w:type="dxa" />
-					</w:tblCellMar>
-				</w:tblPr>`,
+				<w:tblCellMar>
+					<w:left w:w="432" w:type="dxa" />
+					<w:right w:w="144" w:type="dxa" />
+				</w:tblCellMar>
+			</w:tblPr>`,
 			{
 				cellPadding: {
 					top: null,
@@ -131,8 +131,8 @@ describe('Table formatting', () => {
 	describe('Setting table width to a "%" string', () => {
 		test(
 			`<w:tblPr ${ALL_NAMESPACE_DECLARATIONS}>
-					<w:tblW w:w="100%" w:type="nil" />
-				</w:tblPr>`,
+				<w:tblW w:w="100%" w:type="nil" />
+			</w:tblPr>`,
 			{
 				width: { length: '100%', unit: 'nil' },
 			}
@@ -153,11 +153,11 @@ describe('Table formatting', () => {
 	describe('Legacy "left"/"right"', () => {
 		test(
 			`<w:tblPr ${ALL_NAMESPACE_DECLARATIONS}>
-					<w:tblBorders>
-						<w:left w:val="double" w:sz="24" w:space="0" w:color="FF0000"/>
-						<w:right w:val="double" w:sz="24" w:space="0" w:color="FF0000"/>
-					</w:tblBorders>
-				</w:tblPr>`,
+				<w:tblBorders>
+					<w:left w:val="double" w:sz="24" w:space="0" w:color="FF0000"/>
+					<w:right w:val="double" w:sz="24" w:space="0" w:color="FF0000"/>
+				</w:tblBorders>
+			</w:tblPr>`,
 			{
 				borders: {
 					start: {

--- a/lib/properties/test/table-properties.test.ts
+++ b/lib/properties/test/table-properties.test.ts
@@ -14,6 +14,8 @@ const test = createXmlRoundRobinTest<TableProperties>(
 	tablePropertiesToNode
 );
 
+const date = new Date();
+
 describe('Table formatting', () => {
 	test(
 		`<w:tblPr ${ALL_NAMESPACE_DECLARATIONS}>
@@ -45,6 +47,12 @@ describe('Table formatting', () => {
 			<w:tblCellSpacing w:w="60" w:type="dxa" />
 			<w:tblStyleRowBandSize w:val="2" />
 			<w:tblStyleColBandSize w:val="3" />
+			<w:tblPrChange w:id="0" w:author="Vincent" w:date="${date.toISOString()}">
+				<w:tblPr>
+					<w:tblStyle w:val="LightList"/>
+					<w:tblW w:w="1400" w:type="dxa"/>
+				</w:tblPr>
+			</w:tblPrChange>
 		</w:tblPr>`,
 		{
 			style: 'afkicken-van-de-opkikkers',
@@ -91,17 +99,24 @@ describe('Table formatting', () => {
 				insideV: null,
 			},
 			strictColumnWidths: true,
+			change: {
+				id: 0,
+				author: 'Vincent',
+				date: date,
+				style: 'LightList',
+				width: { length: '1400', unit: 'dxa' },
+			},
 		}
 	);
 
 	describe('Legacy schema for cellPadding', () => {
 		test(
 			`<w:tblPr ${ALL_NAMESPACE_DECLARATIONS}>
-				<w:tblCellMar>
-					<w:left w:w="432" w:type="dxa" />
-					<w:right w:w="144" w:type="dxa" />
-				</w:tblCellMar>
-			</w:tblPr>`,
+					<w:tblCellMar>
+						<w:left w:w="432" w:type="dxa" />
+						<w:right w:w="144" w:type="dxa" />
+					</w:tblCellMar>
+				</w:tblPr>`,
 			{
 				cellPadding: {
 					top: null,
@@ -116,8 +131,8 @@ describe('Table formatting', () => {
 	describe('Setting table width to a "%" string', () => {
 		test(
 			`<w:tblPr ${ALL_NAMESPACE_DECLARATIONS}>
-				<w:tblW w:w="100%" w:type="nil" />
-			</w:tblPr>`,
+					<w:tblW w:w="100%" w:type="nil" />
+				</w:tblPr>`,
 			{
 				width: { length: '100%', unit: 'nil' },
 			}
@@ -127,8 +142,8 @@ describe('Table formatting', () => {
 	describe('Setting table width to an unannotated value', () => {
 		test(
 			`<w:tblPr ${ALL_NAMESPACE_DECLARATIONS}>
-				<w:tblW w:w="420" w:type="nil" />
-			</w:tblPr>`,
+					<w:tblW w:w="420" w:type="nil" />
+				</w:tblPr>`,
 			{
 				width: { length: '420', unit: 'nil' },
 			}
@@ -138,11 +153,11 @@ describe('Table formatting', () => {
 	describe('Legacy "left"/"right"', () => {
 		test(
 			`<w:tblPr ${ALL_NAMESPACE_DECLARATIONS}>
-				<w:tblBorders>
-					<w:left w:val="double" w:sz="24" w:space="0" w:color="FF0000"/>
-					<w:right w:val="double" w:sz="24" w:space="0" w:color="FF0000"/>
-				</w:tblBorders>
-			</w:tblPr>`,
+					<w:tblBorders>
+						<w:left w:val="double" w:sz="24" w:space="0" w:color="FF0000"/>
+						<w:right w:val="double" w:sz="24" w:space="0" w:color="FF0000"/>
+					</w:tblBorders>
+				</w:tblPr>`,
 			{
 				borders: {
 					start: {

--- a/lib/properties/test/table-row-properties.test.ts
+++ b/lib/properties/test/table-row-properties.test.ts
@@ -14,17 +14,30 @@ const test = createXmlRoundRobinTest<TableRowProperties>(
 	tableRowPropertiesToNode
 );
 
+const date = new Date();
+
 describe('Table row formatting', () => {
 	test(
 		`<w:trPr ${ALL_NAMESPACE_DECLARATIONS}>
 			<w:tblCellSpacing w:w="60" w:type="dxa" />
 			<w:tblHeader />
 			<w:cantSplit />
+			<w:trPrChange w:id="20" w:author="Gabe" w:date="${date.toISOString()}">
+				<w:trPr> 
+					<w:tblCellSpacing w:w="40" w:type="dxa" />
+				</w:trPr>
+			</w:trPrChange>
 		</w:trPr>`,
 		{
 			isUnsplittable: true,
 			isHeaderRow: true,
 			cellSpacing: pt(3),
+			change: {
+				id: 20,
+				author: 'Gabe',
+				date: date,
+				cellSpacing: pt(2),
+			},
 		}
 	);
 });


### PR DESCRIPTION
This PR extends table row properties, table cell properties and the table grid model so that we're able to track changes made to these properties. 

Similar to existing changes like `Section`, I've created an optional `change` property for each, and this property contains the required change information (`id`, and often optional `author` and `date`). as well as all the properties for the type. 

This PR also updates all the existing tests to include at least one changed parameter, so that we can ensure they're being written correctly to OOXML. 
