### PR TITLE
(chore) Make deno lint observe the whole project

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -18,8 +18,8 @@
 	"importMap": "imports.json",
 	"tasks": {
 		"check": "deno check .",
-		"lint": "deno lint lib",
-		"test": "deno lint lib && deno task check && deno test -A lib",
+		"lint": "deno lint",
+		"test": "deno task lint && deno task check && deno test -A lib",
 		"test:coverage": "deno task test --coverage=coverage && deno coverage --exclude='utils/xml-validation/fontoxml' --exclude='vendor' --lcov --output=coverage/cov.lcov coverage && genhtml --ignore-errors inconsistent --output-directory ./coverage/html_cov ./coverage/cov.lcov && open ./coverage/html_cov/index.html",
 		"precommit": "deno task lint && deno task test"
 	}

--- a/examples/headers-footers.tsx
+++ b/examples/headers-footers.tsx
@@ -1,4 +1,6 @@
+// deno-lint-ignore-file jsx-key
 /** @jsx Docx.jsx */
+
 import { WatermarkText } from '../lib/components/document/src/WatermarkText.ts';
 import Docx, { cm, Image, Paragraph, Section, Text } from '../mod.ts';
 

--- a/examples/hyperlinks.tsx
+++ b/examples/hyperlinks.tsx
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file jsx-key
 /** @jsx Docx.jsx */
 
 import Docx, {

--- a/examples/sections.tsx
+++ b/examples/sections.tsx
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file jsx-key
 /** @jsx Docx.jsx */
 
 import Docx, { cm, Paragraph, Section, Text } from '../mod.ts';

--- a/examples/track-changes/move/track-changes-move-list.tsx
+++ b/examples/track-changes/move/track-changes-move-list.tsx
@@ -1,15 +1,11 @@
 /** @jsx  Docx.jsx */
 import Docx, {
-	Cell,
 	cm,
-	Image,
 	Move,
 	MoveRangeEnd,
 	MoveRangeStart,
 	Paragraph,
-	Row,
 	Section,
-	Table,
 	Text,
 } from '../../../mod.ts';
 

--- a/examples/track-changes/move/track-changes-move-paragraph.tsx
+++ b/examples/track-changes/move/track-changes-move-paragraph.tsx
@@ -1,6 +1,5 @@
 /** @jsx  Docx.jsx */
 import Docx, {
-	cm,
 	Move,
 	MoveRangeEnd,
 	MoveRangeStart,


### PR DESCRIPTION
The aim is to avoid unused variables and lint errors in the project.