### PR TITLE
Create a DeletedText class. 

### DIFF
--- a/examples/track-changes/track-changes-deletion.tsx
+++ b/examples/track-changes/track-changes-deletion.tsx
@@ -1,8 +1,8 @@
 /** @jsx  Docx.jsx */
-import { DeletedText } from '../../lib/components/track-changes/src/DeletedText.ts';
 import Docx, {
 	Cell,
 	cm,
+	DeletedText,
 	Deletion,
 	Image,
 	Paragraph,

--- a/examples/track-changes/track-changes-deletion.tsx
+++ b/examples/track-changes/track-changes-deletion.tsx
@@ -1,4 +1,5 @@
 /** @jsx  Docx.jsx */
+import { DeletedText } from '../../lib/components/track-changes/src/DeletedText.ts';
 import Docx, {
 	Cell,
 	cm,
@@ -59,7 +60,7 @@ await Docx.fromJsx(
 			pilcrow={{ deletion: { id: 1, author: author, date: date } }}
 		>
 			<Deletion id={2} author={author} date={date}>
-				<Text>
+				<DeletedText>
 					The House of Bernarda Alba is a tragedy by Federico García
 					Lorca, set in a small, traditional Andalusian village in
 					southern Spain, just before the Spanish Civil War. The play
@@ -68,7 +69,7 @@ await Docx.fromJsx(
 					eight-year mourning period on her five daughters: Angustias
 					(39), Magdalena (30), Amelia (27), Martirio (24), and Adela
 					(20).
-				</Text>
+				</DeletedText>
 			</Deletion>
 		</Paragraph>
 		<Paragraph>
@@ -86,15 +87,15 @@ await Docx.fromJsx(
 			</Text>
 			{/* Text deletion */}
 			<Deletion id={3} author={author} date={date}>
-				<Text> the youngest daughter.</Text>
+				<DeletedText> the youngest daughter.</DeletedText>
 			</Deletion>
 		</Paragraph>
 		<Paragraph>
 			{/* Text with inline styles deletion */}
 			<Deletion id={4} author={author} date={date}>
-				<Text isItalic isBold>
+				<DeletedText isItalic isBold>
 					As tension escalates,{' '}
-				</Text>
+				</DeletedText>
 			</Deletion>
 			<Text>
 				the household servants Poncia and the Maid observe the emotional
@@ -235,10 +236,10 @@ await Docx.fromJsx(
 			pilcrow={{ deletion: { id: 11, author: author, date: date } }}
 		>
 			<Deletion id={17} author={author} date={date}>
-				<Text>
+				<DeletedText>
 					The play is set in a house in Andalusia, shortly before the
 					Spanish Civil War.
-				</Text>
+				</DeletedText>
 			</Deletion>
 		</Paragraph>
 		<Paragraph
@@ -246,10 +247,10 @@ await Docx.fromJsx(
 			pilcrow={{ deletion: { id: 12, author: author, date: date } }}
 		>
 			<Deletion id={18} author={author} date={date}>
-				<Text>
+				<DeletedText>
 					Bernarda Alba imposes an eight-year mourning period after
 					her husband’s death.
-				</Text>
+				</DeletedText>
 			</Deletion>
 		</Paragraph>
 		<Paragraph
@@ -257,7 +258,9 @@ await Docx.fromJsx(
 			pilcrow={{ deletion: { id: 13, author: author, date: date } }}
 		>
 			<Deletion id={19} author={author} date={date}>
-				<Text>Uses mourning to control her daughters</Text>
+				<DeletedText>
+					Uses mourning to control her daughters
+				</DeletedText>
 			</Deletion>
 		</Paragraph>
 		<Paragraph
@@ -265,7 +268,9 @@ await Docx.fromJsx(
 			pilcrow={{ deletion: { id: 14, author: author, date: date } }}
 		>
 			<Deletion id={20} author={author} date={date}>
-				<Text>No courtship or social contact allowed</Text>
+				<DeletedText>
+					No courtship or social contact allowed
+				</DeletedText>
 			</Deletion>
 		</Paragraph>
 		{/* Image deletion */}
@@ -273,7 +278,7 @@ await Docx.fromJsx(
 			pilcrow={{ deletion: { id: 15, author: author, date: date } }}
 		>
 			<Deletion id={16} author={author} date={date}>
-				<Text>
+				<DeletedText>
 					<Image
 						data={Deno.readFile('assets/oldPhoto.jpg')}
 						width={cm(6)}
@@ -281,7 +286,7 @@ await Docx.fromJsx(
 						title="Title"
 						alt="Description"
 					/>
-				</Text>
+				</DeletedText>
 			</Deletion>
 		</Paragraph>
 	</Section>

--- a/lib/components/document/src/Paragraph.ts
+++ b/lib/components/document/src/Paragraph.ts
@@ -47,12 +47,14 @@ import type { Field } from './Field.ts';
 import type { FootnoteAnchor } from './FootnoteAnchor.ts';
 import type { FootnoteReference } from './FootnoteReference.ts';
 import type { Hyperlink } from './Hyperlink.ts';
+import { DeletedText } from "../../track-changes/src/DeletedText.ts";
 
 /**
  * A type describing the components accepted as children of {@link Paragraph}.
  */
 export type ParagraphChild =
 	| Text
+	| DeletedText
 	| CommentRangeStart
 	| CommentRangeEnd
 	| Comment
@@ -93,6 +95,7 @@ export class Paragraph extends Component<ParagraphProps, ParagraphChild> {
 		'CommentRangeStart',
 		'Hyperlink',
 		'Text',
+		'DeletedText',
 		'Field',
 		'FootnoteReference',
 		'FootnoteAnchor',

--- a/lib/components/document/src/Paragraph.ts
+++ b/lib/components/document/src/Paragraph.ts
@@ -47,14 +47,12 @@ import type { Field } from './Field.ts';
 import type { FootnoteAnchor } from './FootnoteAnchor.ts';
 import type { FootnoteReference } from './FootnoteReference.ts';
 import type { Hyperlink } from './Hyperlink.ts';
-import { DeletedText } from "../../track-changes/src/DeletedText.ts";
 
 /**
  * A type describing the components accepted as children of {@link Paragraph}.
  */
 export type ParagraphChild =
 	| Text
-	| DeletedText
 	| CommentRangeStart
 	| CommentRangeEnd
 	| Comment
@@ -95,7 +93,6 @@ export class Paragraph extends Component<ParagraphProps, ParagraphChild> {
 		'CommentRangeStart',
 		'Hyperlink',
 		'Text',
-		'DeletedText',
 		'Field',
 		'FootnoteReference',
 		'FootnoteAnchor',

--- a/lib/components/document/src/Text.ts
+++ b/lib/components/document/src/Text.ts
@@ -27,7 +27,6 @@ import {
 import { create } from '../../../utilities/src/dom.ts';
 import { QNS } from '../../../utilities/src/namespaces.ts';
 import { evaluateXPathToMap } from '../../../utilities/src/xquery.ts';
-import { Deletion } from '../../track-changes/src/Deletion.ts';
 import type { Break } from './Break.ts';
 import type { FieldRangeEnd } from './FieldRangeEnd.ts';
 import type { FieldRangeInstruction } from './FieldRangeInstruction.ts';
@@ -87,13 +86,6 @@ export class Text extends Component<TextProps, TextChild> {
 	 * Creates an XML DOM node for this component instance.
 	 */
 	public override async toNode(ancestry: ComponentAncestor[]): Promise<Node> {
-		// It's necessary to verify if the text run content node is inside a <del> element,
-		// because according to the schema, the text node should be <delText> instead of <t>
-		// https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_del_topic_ID0ESZZV.html
-		const asTextDeletion = ancestry.some(
-			(ancestor) => ancestor instanceof Deletion
-		);
-		const anc = [this, ...ancestry];
 		return create(
 			`
 				element ${QNS.w}r {
@@ -107,9 +99,7 @@ export class Text extends Component<TextProps, TextChild> {
 					this.children.map((child) => {
 						if (typeof child === 'string') {
 							return create(
-								`element ${QNS.w}${
-									asTextDeletion ? 'delText' : 't'
-								} {
+								`element ${QNS.w}t {  
 									attribute xml:space { "preserve" },
 									$text
 								}`,
@@ -118,7 +108,7 @@ export class Text extends Component<TextProps, TextChild> {
 								}
 							);
 						}
-						return child.toNode(anc);
+						return child.toNode(ancestry);
 					})
 				),
 			}
@@ -149,7 +139,6 @@ export class Text extends Component<TextProps, TextChild> {
 							${QNS.w}tab,
 							${QNS.w}drawing,
 							${QNS.w}t/text(),
-							${QNS.w}delText/text(),
 							${QNS.w}fldChar,
 							${QNS.w}instrText
 						)

--- a/lib/components/document/src/Text.ts
+++ b/lib/components/document/src/Text.ts
@@ -67,6 +67,13 @@ export type TextProps = TextProperties;
  * are in fact different props or styles on the `<Text>` component.
  */
 export class Text extends Component<TextProps, TextChild> {
+	// Introduce a __brand property so that we cannot use Text and DeletedText interchangeably.
+	// TypeScript's structural typing would allow us to do so otherwise.
+	// readonly __brand: string;
+	// constructor(props: TextProps, child: TextChild) {
+	// 	super(props, child);
+	// 	this.__brand = 'regular';
+	// }
 	public static override readonly children: string[] = [
 		'Break',
 		'FieldRangeEnd',

--- a/lib/components/document/src/Text.ts
+++ b/lib/components/document/src/Text.ts
@@ -36,7 +36,7 @@ import type { FootnoteContinuationSeparator } from './FootnoteContinuationSepara
 import type { FootnoteSeparator } from './FootnoteSeparator.ts';
 import type { Image } from './Image.ts';
 import type { NonBreakingHyphen } from './NonBreakingHyphen.ts';
-import type { Symbol } from './Symbol.ts';
+import type { Symbol as CharSymbol } from './Symbol.ts';
 import type { Tab } from './Tab.ts';
 
 /**
@@ -54,8 +54,10 @@ export type TextChild =
 	| Image
 	| NonBreakingHyphen
 	// eslint-disable-next-line @typescript-eslint/ban-types
-	| Symbol
+	| CharSymbol
 	| Tab;
+
+const __brand: symbol = Symbol();
 
 /**
  * A type describing the props accepted by {@link Text}.
@@ -69,11 +71,9 @@ export type TextProps = TextProperties;
 export class Text extends Component<TextProps, TextChild> {
 	// Introduce a __brand property so that we cannot use Text and DeletedText interchangeably.
 	// TypeScript's structural typing would allow us to do so otherwise.
-	// readonly __brand: string;
-	// constructor(props: TextProps, child: TextChild) {
-	// 	super(props, child);
-	// 	this.__brand = 'regular';
-	// }
+
+	readonly [__brand] = 'regularText';
+
 	public static override readonly children: string[] = [
 		'Break',
 		'FieldRangeEnd',

--- a/lib/components/document/src/Text.ts
+++ b/lib/components/document/src/Text.ts
@@ -57,7 +57,7 @@ export type TextChild =
 	| CharSymbol
 	| Tab;
 
-const __brand: symbol = Symbol();
+const __brand: unique symbol = Symbol();
 
 /**
  * A type describing the props accepted by {@link Text}.

--- a/lib/components/track-changes/src/DeletedText.ts
+++ b/lib/components/track-changes/src/DeletedText.ts
@@ -36,7 +36,7 @@ import type { FootnoteContinuationSeparator } from '../../document/src/FootnoteC
 import type { FootnoteSeparator } from '../../document/src/FootnoteSeparator.ts';
 import type { Image } from '../../document/src/Image.ts';
 import type { NonBreakingHyphen } from '../../document/src/NonBreakingHyphen.ts';
-import type { Symbol } from '../../document/src/Symbol.ts';
+import type { Symbol as CharSymbol } from '../../document/src/Symbol.ts';
 import type { Tab } from '../../document/src/Tab.ts';
 
 /**
@@ -54,8 +54,10 @@ export type DeletedTextChild =
 	| Image
 	| NonBreakingHyphen
 	// eslint-disable-next-line @typescript-eslint/ban-types
-	| Symbol
+	| CharSymbol
 	| Tab;
+
+const __brand: symbol = Symbol();
 
 /**
  * A type describing the props accepted by {@link DeletedText}.
@@ -68,6 +70,8 @@ export type DeletedTextProps = TextProperties;
  * the document has been removed. `DeletedText` must have a parent {@link Deletion}.
  */
 export class DeletedText extends Component<DeletedTextProps, DeletedTextChild> {
+	readonly [__brand] = 'deletedText';
+
 	public static override readonly children: string[] = [
 		'Break',
 		'FieldRangeEnd',

--- a/lib/components/track-changes/src/DeletedText.ts
+++ b/lib/components/track-changes/src/DeletedText.ts
@@ -38,10 +38,10 @@ import type { Image } from '../../document/src/Image.ts';
 import type { NonBreakingHyphen } from '../../document/src/NonBreakingHyphen.ts';
 import type { Symbol } from '../../document/src/Symbol.ts';
 import type { Tab } from '../../document/src/Tab.ts';
-import type { Text } from "../../document/src/Text.ts";
+import type { Text } from '../../document/src/Text.ts';
 
 /**
- * A type describing the components accepted as children of {@link Text}.
+ * A type describing the components accepted as children of {@link DeletedText}.
  */
 export type DeletedTextChild =
 	| string
@@ -59,13 +59,14 @@ export type DeletedTextChild =
 	| Tab;
 
 /**
- * A type describing the props accepted by {@link Text}.
+ * A type describing the props accepted by {@link DeletedText}.
  */
 export type DeletedTextProps = TextProperties;
 
 /**
- * A component that represents text. All inline formatting options, such as bold/italic/underline,
- * are in fact different props or styles on the `<Text>` component.
+ * A component that represents deleted text.
+ * Deleted text is used within Word's track changes to indicate that text content in
+ * the document has been removed. `DeletedText` must have a parent {@link Deletion}.
  */
 export class DeletedText extends Component<DeletedTextProps, DeletedTextChild> {
 	public static override readonly children: string[] = [

--- a/lib/components/track-changes/src/DeletedText.ts
+++ b/lib/components/track-changes/src/DeletedText.ts
@@ -1,0 +1,162 @@
+// Import without assignment ensures Deno does not tree-shake this component. To avoid circular
+// definitions, components register themselves in a side-effect of their module.
+import '../../document/src/Break.ts';
+import '../../document/src/FieldRangeEnd.ts';
+import '../../document/src/FieldRangeInstruction.ts';
+import '../../document/src/FieldRangeSeparator.ts';
+import '../../document/src/FieldRangeStart.ts';
+import '../../document/src/Image.ts';
+import '../../document/src/NonBreakingHyphen.ts';
+import '../../document/src/Symbol.ts';
+import '../../document/src/Tab.ts';
+
+import {
+	Component,
+	type ComponentAncestor,
+	type ComponentContext,
+} from '../../../classes/src/Component.ts';
+import {
+	type TextProperties,
+	textPropertiesFromNode,
+	textPropertiesToNode,
+} from '../../../properties/src/text-properties.ts';
+import {
+	createChildComponentsFromNodes,
+	registerComponent,
+} from '../../../utilities/src/components.ts';
+import { create } from '../../../utilities/src/dom.ts';
+import { QNS } from '../../../utilities/src/namespaces.ts';
+import { evaluateXPathToMap } from '../../../utilities/src/xquery.ts';
+import type { Break } from '../../document/src/Break.ts';
+import type { FieldRangeEnd } from '../../document/src/FieldRangeEnd.ts';
+import type { FieldRangeInstruction } from '../../document/src/FieldRangeInstruction.ts';
+import type { FieldRangeSeparator } from '../../document/src/FieldRangeSeparator.ts';
+import type { FieldRangeStart } from '../../document/src/FieldRangeStart.ts';
+import type { FootnoteContinuationSeparator } from '../../document/src/FootnoteContinuationSeparator.ts';
+import type { FootnoteSeparator } from '../../document/src/FootnoteSeparator.ts';
+import type { Image } from '../../document/src/Image.ts';
+import type { NonBreakingHyphen } from '../../document/src/NonBreakingHyphen.ts';
+import type { Symbol } from '../../document/src/Symbol.ts';
+import type { Tab } from '../../document/src/Tab.ts';
+import type { Text } from "../../document/src/Text.ts";
+
+/**
+ * A type describing the components accepted as children of {@link Text}.
+ */
+export type DeletedTextChild =
+	| string
+	| Break
+	| FieldRangeEnd
+	| FieldRangeInstruction
+	| FieldRangeSeparator
+	| FieldRangeStart
+	| FootnoteSeparator
+	| FootnoteContinuationSeparator
+	| Image
+	| NonBreakingHyphen
+	// eslint-disable-next-line @typescript-eslint/ban-types
+	| Symbol
+	| Tab;
+
+/**
+ * A type describing the props accepted by {@link Text}.
+ */
+export type DeletedTextProps = TextProperties;
+
+/**
+ * A component that represents text. All inline formatting options, such as bold/italic/underline,
+ * are in fact different props or styles on the `<Text>` component.
+ */
+export class DeletedText extends Component<DeletedTextProps, DeletedTextChild> {
+	public static override readonly children: string[] = [
+		'Break',
+		'FieldRangeEnd',
+		'FieldRangeInstruction',
+		'FieldRangeSeparator',
+		'FieldRangeStart',
+		'FootnoteSeparator',
+		'FootnoteContinuationSeparator',
+		'Image',
+		'NonBreakingHyphen',
+		'Symbol',
+		'Tab',
+	];
+	public static override readonly mixed: boolean = true;
+
+	/**
+	 * Creates an XML DOM node for this component instance.
+	 */
+	public override async toNode(ancestry: ComponentAncestor[]): Promise<Node> {
+		return create(
+			`
+				element ${QNS.w}r {
+					$rpr,
+					$children
+				}
+			`,
+			{
+				rpr: await textPropertiesToNode(this.props),
+				children: await Promise.all(
+					this.children.map((child) => {
+						if (typeof child === 'string') {
+							return create(
+								`element ${QNS.w}delText {
+									attribute xml:space { "preserve" },
+									$text
+								}`,
+								{
+									text: child,
+								}
+							);
+						}
+						return child.toNode(ancestry);
+					})
+				),
+			}
+		);
+	}
+
+	/**
+	 * Asserts whether or not a given XML node correlates with this component.
+	 */
+	static override matchesNode(node: Node): boolean {
+		return node.nodeName === 'w:r';
+	}
+
+	/**
+	 * Instantiate this component from the XML in an existing DOCX file.
+	 */
+	static override fromNode(node: Node, context: ComponentContext): Text {
+		const { children, rpr } = evaluateXPathToMap<{
+			rpr: Node;
+			children: Node[];
+		}>(
+			`
+				map {
+					"rpr": ./${QNS.w}rPr,
+					"children": array{
+						./(
+							${QNS.w}br,
+							${QNS.w}tab,
+							${QNS.w}drawing,
+							${QNS.w}delText/text(),
+							${QNS.w}fldChar,
+							${QNS.w}instrText
+						)
+					}
+				}
+			`,
+			node
+		);
+		return new DeletedText(
+			textPropertiesFromNode(rpr) as DeletedTextProps,
+			...createChildComponentsFromNodes<DeletedTextChild>(
+				this.children,
+				children,
+				context
+			)
+		);
+	}
+}
+
+registerComponent(DeletedText);

--- a/lib/components/track-changes/src/DeletedText.ts
+++ b/lib/components/track-changes/src/DeletedText.ts
@@ -38,7 +38,6 @@ import type { Image } from '../../document/src/Image.ts';
 import type { NonBreakingHyphen } from '../../document/src/NonBreakingHyphen.ts';
 import type { Symbol } from '../../document/src/Symbol.ts';
 import type { Tab } from '../../document/src/Tab.ts';
-import type { Text } from '../../document/src/Text.ts';
 
 /**
  * A type describing the components accepted as children of {@link DeletedText}.
@@ -127,7 +126,10 @@ export class DeletedText extends Component<DeletedTextProps, DeletedTextChild> {
 	/**
 	 * Instantiate this component from the XML in an existing DOCX file.
 	 */
-	static override fromNode(node: Node, context: ComponentContext): Text {
+	static override fromNode(
+		node: Node,
+		context: ComponentContext
+	): DeletedText {
 		const { children, rpr } = evaluateXPathToMap<{
 			rpr: Node;
 			children: Node[];

--- a/lib/components/track-changes/src/DeletedText.ts
+++ b/lib/components/track-changes/src/DeletedText.ts
@@ -101,7 +101,10 @@ export class DeletedText extends Component<DeletedTextProps, DeletedTextChild> {
 	 * Asserts whether or not a given XML node correlates with this component.
 	 */
 	static override matchesNode(node: Node): boolean {
-		return node.nodeName === 'w:r';
+		return (
+			`Q{${(node as Element).namespaceURI}}` === QNS.w &&
+			(node as Element).localName === 'r'
+		);
 	}
 
 	/**

--- a/lib/components/track-changes/src/DeletedText.ts
+++ b/lib/components/track-changes/src/DeletedText.ts
@@ -57,7 +57,7 @@ export type DeletedTextChild =
 	| CharSymbol
 	| Tab;
 
-const __brand: symbol = Symbol();
+const __brand: unique symbol = Symbol();
 
 /**
  * A type describing the props accepted by {@link DeletedText}.

--- a/lib/components/track-changes/src/DeletedText.ts
+++ b/lib/components/track-changes/src/DeletedText.ts
@@ -27,35 +27,12 @@ import {
 import { create } from '../../../utilities/src/dom.ts';
 import { QNS } from '../../../utilities/src/namespaces.ts';
 import { evaluateXPathToMap } from '../../../utilities/src/xquery.ts';
-import type { Break } from '../../document/src/Break.ts';
-import type { FieldRangeEnd } from '../../document/src/FieldRangeEnd.ts';
-import type { FieldRangeInstruction } from '../../document/src/FieldRangeInstruction.ts';
-import type { FieldRangeSeparator } from '../../document/src/FieldRangeSeparator.ts';
-import type { FieldRangeStart } from '../../document/src/FieldRangeStart.ts';
-import type { FootnoteContinuationSeparator } from '../../document/src/FootnoteContinuationSeparator.ts';
-import type { FootnoteSeparator } from '../../document/src/FootnoteSeparator.ts';
-import type { Image } from '../../document/src/Image.ts';
-import type { NonBreakingHyphen } from '../../document/src/NonBreakingHyphen.ts';
-import type { Symbol as CharSymbol } from '../../document/src/Symbol.ts';
-import type { Tab } from '../../document/src/Tab.ts';
+import type { TextChild } from '../../document/src/Text.ts';
 
 /**
  * A type describing the components accepted as children of {@link DeletedText}.
  */
-export type DeletedTextChild =
-	| string
-	| Break
-	| FieldRangeEnd
-	| FieldRangeInstruction
-	| FieldRangeSeparator
-	| FieldRangeStart
-	| FootnoteSeparator
-	| FootnoteContinuationSeparator
-	| Image
-	| NonBreakingHyphen
-	// eslint-disable-next-line @typescript-eslint/ban-types
-	| CharSymbol
-	| Tab;
+export type DeletedTextChild = TextChild;
 
 const __brand: unique symbol = Symbol();
 

--- a/lib/components/track-changes/src/Deletion.ts
+++ b/lib/components/track-changes/src/Deletion.ts
@@ -19,7 +19,7 @@ import type { CommentRangeStart } from '../../comments/src/CommentRangeStart.ts'
 import type { BookmarkRangeEnd } from '../../document/src/BookmarkRangeEnd.ts';
 import type { BookmarkRangeStart } from '../../document/src/BookmarkRangeStart.ts';
 import type { FootnoteReference } from '../../document/src/FootnoteReference.ts';
-import type { Text } from '../../document/src/Text.ts';
+import type { DeletedText } from "./DeletedText.ts";
 import type { Insertion } from './Insertion.ts';
 import type { Move } from './Move.ts';
 import type { MoveFromRangeEnd } from './MoveFromRangeEnd.ts';
@@ -34,7 +34,7 @@ export type DeletionChild =
 	| BookmarkRangeEnd
 	| CommentRangeStart
 	| CommentRangeEnd
-	| Text
+	| DeletedText
 	| Move
 	| MoveToRangeStart
 	| MoveToRangeEnd
@@ -64,7 +64,7 @@ export class Deletion extends Component<DeletionProps, DeletionChild> {
 		'BookmarkRangeStart',
 		'CommentRangeStart',
 		'CommentRangeEnd',
-		'Text',
+		'DeletedText',
 		'Move',
 		'MoveToRangeStart',
 		'MoveToRangeEnd',

--- a/lib/components/track-changes/test/DeletedText.test.ts
+++ b/lib/components/track-changes/test/DeletedText.test.ts
@@ -1,0 +1,55 @@
+import { expect } from 'std/expect';
+import { describe, it } from 'std/testing/bdd';
+
+import { Archive } from '../../../classes/src/Archive.ts';
+import type { ComponentContext } from '../../../classes/src/Component.ts';
+import { create, serialize } from '../../../utilities/src/dom.ts';
+import { NamespaceUri } from '../../../utilities/src/namespaces.ts';
+import { DeletedText } from "../src/DeletedText.ts";
+
+const emptyContext: ComponentContext = {
+	archive: new Archive(),
+	relationships: null,
+};
+
+describe('Deleted Text', () => {
+	const deletedText = DeletedText.fromNode(
+		create(`
+			<w:r xmlns:w="${NamespaceUri.w}">
+				<w:rPr>
+					<w:b />
+				</w:rPr>
+				<w:delText>This text contains</w:delText>
+				<w:br w:type="page" />
+				<w:delText>a page break</w:delText>
+			</w:r>
+		`),
+		emptyContext
+	);
+
+	it('parses props correctly', () => {
+		expect(deletedText.props.isBold).toBeTruthy();
+	});
+
+	it('parses children correctly', () => {
+		expect(deletedText.children).toHaveLength(3);
+		expect(deletedText.children.map((child) => child.constructor.name)).toEqual([
+			'String',
+			'Break',
+			'String',
+		]);
+	});
+
+	it('serializes correctly', async () => {
+		expect(serialize(await deletedText.toNode([]))).toBe(
+			`
+				<r xmlns="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+					<rPr><b/></rPr>
+					<delText xml:space="preserve">This text contains</delText>
+					<br xmlns:ns1="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ns1:type="page"/>
+					<delText xml:space="preserve">a page break</delText>
+				</r>
+			`.replace(/\n|\t/g, '')
+		);
+	});
+});

--- a/lib/components/track-changes/test/Deletion.test.ts
+++ b/lib/components/track-changes/test/Deletion.test.ts
@@ -11,6 +11,7 @@ import { BookmarkRangeEnd } from '../../document/src/BookmarkRangeEnd.ts';
 import { BookmarkRangeStart } from '../../document/src/BookmarkRangeStart.ts';
 import { Paragraph } from '../../document/src/Paragraph.ts';
 import { Text } from '../../document/src/Text.ts';
+import { DeletedText } from '../src/DeletedText.ts';
 import { MoveFromRangeEnd } from '../../track-changes/src/MoveFromRangeEnd.ts';
 import { MoveFromRangeStart } from '../../track-changes/src/MoveFromRangeStart.ts';
 import { MoveToRangeEnd } from '../../track-changes/src/MoveToRangeEnd.ts';
@@ -31,10 +32,10 @@ describe('Deletion', () => {
 			const deletedTextNode = create(
 				`<w:p xmlns:w="${NamespaceUri.w}">
 					<w:del w:id="1" w:author="Luis" w:date="${date.toISOString()}">
-						<w:r><w:t>This is a new paragraph</w:t></w:r>
+						<w:r><w:delText>This is a new paragraph</w:delText></w:r>
 					</w:del>
 					<w:del w:id="2" w:author="Roy" w:date="${date.toISOString()}">
-						<w:r><w:t>This is a another new paragraph</w:t></w:r>
+						<w:r><w:delText>This is a another new paragraph</w:delText></w:r>
 					</w:del>
 				</w:p>
 				`,
@@ -43,11 +44,11 @@ describe('Deletion', () => {
 
 			const deletedText1 = new Deletion(
 				{ author: 'Luis', date: date, id: 1 },
-				new Text({}, 'This is a new paragraph')
+				new DeletedText({}, 'This is a new paragraph')
 			);
 			const deletedText2 = new Deletion(
 				{ author: 'Roy', date: date, id: 2 },
-				new Text({}, 'This is a another new paragraph')
+				new DeletedText({}, 'This is a another new paragraph')
 			);
 			const deletedTextAsObject = new Paragraph(
 				{},
@@ -98,10 +99,10 @@ describe('Deletion', () => {
 			const deletedTextNode = create(
 				`<w:p xmlns:w="${NamespaceUri.w}">
 					<w:del w:id="1">
-						<w:r><w:t>This is a new paragraph</w:t></w:r>
+						<w:r><w:delText>This is a new paragraph</w:delText></w:r>
 					</w:del>
 					<w:del w:id="2">
-						<w:r><w:t>This is a another new paragraph</w:t></w:r>
+						<w:r><w:delText>This is a another new paragraph</w:delText></w:r>
 					</w:del>
 				</w:p>
 				`,
@@ -110,11 +111,11 @@ describe('Deletion', () => {
 
 			const deletedText1 = new Deletion(
 				{ id: 1 },
-				new Text({}, 'This is a new paragraph')
+				new DeletedText({}, 'This is a new paragraph')
 			);
 			const deletedText2 = new Deletion(
 				{ id: 2 },
-				new Text({}, 'This is a another new paragraph')
+				new DeletedText({}, 'This is a another new paragraph')
 			);
 			const deletedTextAsObject = new Paragraph(
 				{},
@@ -416,14 +417,14 @@ describe('Deletion', () => {
 										NamespaceUri.w
 									}" ns1:id="0" ns1:date="${date.toISOString()}" ns1:author="Gabe">
 										<r>
-											<delText xml:space="preserve">Moved content</delText>
+											<t xml:space="preserve">Moved content</t>
 										</r>
 									</moveTo>
 									<moveFrom xmlns:ns1="${
 										NamespaceUri.w
 									}" ns1:id="0" ns1:date="${date.toISOString()}" ns1:author="Gabe">
 										<r>
-											<delText xml:space="preserve">Moved content</delText>
+											<t xml:space="preserve">Moved content</t>
 										</r>
 									</moveFrom>
 								</del>
@@ -434,14 +435,14 @@ describe('Deletion', () => {
 										NamespaceUri.w
 									}" ns1:id="1" ns1:date="${date.toISOString()}" ns1:author="Gabe">
 										<r>
-											<delText xml:space="preserve">More moved content</delText>
+											<t xml:space="preserve">More moved content</t>
 										</r>
 									</moveTo>
 									<moveFrom xmlns:ns1="${
 										NamespaceUri.w
 									}" ns1:id="1" ns1:date="${date.toISOString()}" ns1:author="Gabe">
 										<r>
-											<delText xml:space="preserve">More moved content</delText>
+											<t xml:space="preserve">More moved content</t>
 										</r>
 									</moveFrom>
 								</del>
@@ -562,7 +563,7 @@ describe('Deletion', () => {
 			{ pilcrow: { deletion: { author: 'Luis', date: date, id: 1 } } },
 			new Deletion(
 				{ author: 'Luis', date: date, id: 1 },
-				new Text({}, 'This is a deleted paragraph')
+				new DeletedText({}, 'This is a deleted paragraph')
 			)
 		);
 

--- a/lib/utilities/src/jsx.ts
+++ b/lib/utilities/src/jsx.ts
@@ -61,14 +61,20 @@ export async function jsx<C extends Component>(
 						isComponentDefinition(component) &&
 						!component.mixed
 					) {
-						child = new Text({}, child) as ComponentChild<C>;
+						child = new Text(
+							{},
+							child
+						) as unknown as ComponentChild<C>;
 					}
 					const isValid =
 						!isComponentDefinition(component) ||
 						(component.mixed && typeof child === 'string') ||
 						component.children.includes(child.constructor.name);
 					if (!isValid) {
-						if (child.constructor === Text && component === Text) {
+						if (
+							child.constructor === component &&
+							child.constructor === Text
+						) {
 							Object.assign((child as Text).props, props);
 						}
 						nodes.push(child);

--- a/mod.ts
+++ b/mod.ts
@@ -126,6 +126,11 @@ export {
 	type WatermarkTextProps,
 } from './lib/components/document/src/WatermarkText.ts';
 export {
+	DeletedText,
+	type DeletedTextChild,
+	type DeletedTextProps,
+} from './lib/components/track-changes/src/DeletedText.ts';
+export {
 	Deletion,
 	type DeletionChild,
 	type DeletionProps,


### PR DESCRIPTION
This PR creates a `DeletedText` class for use inside the `Deletion` component. This removes the need to check the ancestry of a `Text` component to determine if it should be created as `delText` or `t` when we create a Word document. 