### PR TITLE
Split `moveRangeStart` and `moveRangeEnd` into corresponding `To` and `From` components

### DIFF
--- a/examples/track-changes/move/track-changes-move-image.tsx
+++ b/examples/track-changes/move/track-changes-move-image.tsx
@@ -3,8 +3,10 @@ import Docx, {
 	cm,
 	Image,
 	Move,
-	MoveRangeEnd,
-	MoveRangeStart,
+	MoveFromRangeEnd,
+	MoveFromRangeStart,
+	MoveToRangeEnd,
+	MoveToRangeStart,
 	Paragraph,
 	Section,
 	Text,
@@ -17,9 +19,8 @@ await Docx.fromJsx(
 	<Section>
 		{/* Image MoveTo */}
 		<Paragraph>
-			<MoveRangeStart
+			<MoveToRangeStart
 				id={11}
-				type="to"
 				name="move_1"
 				author={author}
 				date={date}
@@ -35,7 +36,7 @@ await Docx.fromJsx(
 					/>
 				</Text>
 			</Move>
-			<MoveRangeEnd id={11} type="to" />
+			<MoveToRangeEnd id={11} />
 		</Paragraph>
 		<Paragraph>
 			<Text isBold isCaps>
@@ -44,9 +45,8 @@ await Docx.fromJsx(
 		</Paragraph>
 		{/* Image MoveFrom */}
 		<Paragraph>
-			<MoveRangeStart
+			<MoveFromRangeStart
 				id={8}
-				type="from"
 				name="move_1"
 				author={author}
 				date={date}
@@ -62,7 +62,7 @@ await Docx.fromJsx(
 					/>
 				</Text>
 			</Move>
-			<MoveRangeEnd id={8} type="from" />
+			<MoveFromRangeEnd id={8} />
 		</Paragraph>
 	</Section>
 ).toFile('track-changes-move-image.docx');

--- a/examples/track-changes/move/track-changes-move-list.tsx
+++ b/examples/track-changes/move/track-changes-move-list.tsx
@@ -2,8 +2,10 @@
 import Docx, {
 	cm,
 	Move,
-	MoveRangeEnd,
-	MoveRangeStart,
+	MoveFromRangeEnd,
+	MoveFromRangeStart,
+	MoveToRangeEnd,
+	MoveToRangeStart,
 	Paragraph,
 	Section,
 	Text,
@@ -59,9 +61,8 @@ await Docx.fromJsx(
 				move: { id: 26, type: 'to', author: author, date: date },
 			}}
 		>
-			<MoveRangeStart
+			<MoveToRangeStart
 				id={27}
-				type="to"
 				name="move_3"
 				author={author}
 				date={date}
@@ -106,7 +107,7 @@ await Docx.fromJsx(
 				<Text>No courtship or social contact allowed</Text>
 			</Move>
 		</Paragraph>
-		<MoveRangeEnd id={27} type="to" />
+		<MoveToRangeEnd id={27} />
 
 		<Paragraph>
 			<Text>Key Points List</Text>
@@ -119,9 +120,8 @@ await Docx.fromJsx(
 				move: { id: 17, type: 'from', author: author, date: date },
 			}}
 		>
-			<MoveRangeStart
+			<MoveFromRangeStart
 				id={18}
-				type="from"
 				name="move_3"
 				author={author}
 				date={date}
@@ -166,6 +166,6 @@ await Docx.fromJsx(
 				<Text>No courtship or social contact allowed</Text>
 			</Move>
 		</Paragraph>
-		<MoveRangeEnd id={18} type="from" />
+		<MoveFromRangeEnd id={18} />
 	</Section>
 ).toFile('track-changes-move-list.docx');

--- a/examples/track-changes/move/track-changes-move-paragraph.tsx
+++ b/examples/track-changes/move/track-changes-move-paragraph.tsx
@@ -1,8 +1,10 @@
 /** @jsx  Docx.jsx */
 import Docx, {
 	Move,
-	MoveRangeEnd,
-	MoveRangeStart,
+	MoveFromRangeEnd,
+	MoveFromRangeStart,
+	MoveToRangeEnd,
+	MoveToRangeStart,
 	Paragraph,
 	Section,
 	Text,
@@ -19,9 +21,8 @@ await Docx.fromJsx(
 				move: { id: 0, type: 'from', author: author, date: date },
 			}}
 		>
-			<MoveRangeStart
+			<MoveFromRangeStart
 				id={1}
-				type="from"
 				name="move_0"
 				author={author}
 				date={date}
@@ -38,7 +39,7 @@ await Docx.fromJsx(
 					(20).
 				</Text>
 			</Move>
-			<MoveRangeEnd id={1} type="from" />
+			<MoveFromRangeEnd id={1} />
 		</Paragraph>
 		<Paragraph>
 			<Text>
@@ -60,9 +61,8 @@ await Docx.fromJsx(
 				move: { id: 3, type: 'to', author: author, date: date },
 			}}
 		>
-			<MoveRangeStart
+			<MoveToRangeStart
 				id={4}
-				type="to"
 				name="move_0"
 				author={author}
 				date={date}
@@ -79,7 +79,7 @@ await Docx.fromJsx(
 					(20).
 				</Text>
 			</Move>
-			<MoveRangeEnd id={4} type="to" />
+			<MoveToRangeEnd id={4} />
 		</Paragraph>
 		<Paragraph>
 			<Text>

--- a/examples/track-changes/move/track-changes-move-table.tsx
+++ b/examples/track-changes/move/track-changes-move-table.tsx
@@ -2,8 +2,10 @@
 import Docx, {
 	Cell,
 	Move,
-	MoveRangeEnd,
-	MoveRangeStart,
+	MoveFromRangeEnd,
+	MoveFromRangeStart,
+	MoveToRangeEnd,
+	MoveToRangeStart,
 	Paragraph,
 	Row,
 	Section,
@@ -30,9 +32,8 @@ await Docx.fromJsx(
 							},
 						}}
 					>
-						<MoveRangeStart
+						<MoveToRangeStart
 							id={16}
-							type="to"
 							name="move_2"
 							author={author}
 							date={date}
@@ -131,7 +132,7 @@ await Docx.fromJsx(
 				</Cell>
 			</Row>
 		</Table>
-		<MoveRangeEnd id={16} type="to" />
+		<MoveToRangeEnd id={16} />
 		<Paragraph>
 			<Text isBold isCaps>
 				Summary Table
@@ -151,9 +152,8 @@ await Docx.fromJsx(
 							},
 						}}
 					>
-						<MoveRangeStart
+						<MoveFromRangeStart
 							id={13}
-							type="from"
 							name="move_2"
 							author={author}
 							date={date}
@@ -252,6 +252,6 @@ await Docx.fromJsx(
 				</Cell>
 			</Row>
 		</Table>
-		<MoveRangeEnd id={13} type="from" />
+		<MoveFromRangeEnd id={13} />
 	</Section>
 ).toFile('track-changes-move-table.docx');

--- a/lib/components/document/src/Paragraph.ts
+++ b/lib/components/document/src/Paragraph.ts
@@ -37,8 +37,10 @@ import type { Text } from '../../document/src/Text.ts';
 import type { Deletion } from '../../track-changes/src/Deletion.ts';
 import type { Insertion } from '../../track-changes/src/Insertion.ts';
 import type { Move } from '../../track-changes/src/Move.ts';
-import type { MoveRangeEnd } from '../../track-changes/src/MoveRangeEnd.ts';
-import type { MoveRangeStart } from '../../track-changes/src/MoveRangeStart.ts';
+import type { MoveFromRangeEnd } from '../../track-changes/src/MoveFromRangeEnd.ts';
+import type { MoveFromRangeStart } from '../../track-changes/src/MoveFromRangeStart.ts';
+import type { MoveToRangeEnd } from '../../track-changes/src/MoveToRangeEnd.ts';
+import type { MoveToRangeStart } from '../../track-changes/src/MoveToRangeStart.ts';
 import type { BookmarkRangeEnd } from './BookmarkRangeEnd.ts';
 import type { BookmarkRangeStart } from './BookmarkRangeStart.ts';
 import type { Field } from './Field.ts';
@@ -60,8 +62,10 @@ export type ParagraphChild =
 	| Field
 	| FootnoteReference
 	| Move
-	| MoveRangeStart
-	| MoveRangeEnd
+	| MoveToRangeStart
+	| MoveToRangeEnd
+	| MoveFromRangeStart
+	| MoveFromRangeEnd
 	| FootnoteAnchor
 	| Insertion
 	| Deletion;
@@ -93,8 +97,10 @@ export class Paragraph extends Component<ParagraphProps, ParagraphChild> {
 		'FootnoteReference',
 		'FootnoteAnchor',
 		'Move',
-		'MoveRangeStart',
-		'MoveRangeEnd',
+		'MoveToRangeStart',
+		'MoveToRangeEnd',
+		'MoveFromRangeStart',
+		'MoveFromRangeEnd',
 		'Insertion',
 		'Deletion',
 	];

--- a/lib/components/track-changes/src/Deletion.ts
+++ b/lib/components/track-changes/src/Deletion.ts
@@ -22,9 +22,10 @@ import type { FootnoteReference } from '../../document/src/FootnoteReference.ts'
 import type { Text } from '../../document/src/Text.ts';
 import type { Insertion } from './Insertion.ts';
 import type { Move } from './Move.ts';
-import type { MoveRangeEnd } from './MoveRangeEnd.ts';
-import type { MoveRangeStart } from './MoveRangeStart.ts';
-
+import type { MoveFromRangeEnd } from './MoveFromRangeEnd.ts';
+import type { MoveFromRangeStart } from './MoveFromRangeStart.ts';
+import type { MoveToRangeEnd } from './MoveToRangeEnd.ts';
+import type { MoveToRangeStart } from './MoveToRangeStart.ts';
 /**
  * A type specifying the children of {@link Deletion}.
  */
@@ -35,8 +36,10 @@ export type DeletionChild =
 	| CommentRangeEnd
 	| Text
 	| Move
-	| MoveRangeStart
-	| MoveRangeEnd
+	| MoveToRangeStart
+	| MoveToRangeEnd
+	| MoveFromRangeStart
+	| MoveFromRangeEnd
 	| Deletion
 	| Insertion
 	| FootnoteReference;
@@ -63,8 +66,10 @@ export class Deletion extends Component<DeletionProps, DeletionChild> {
 		'CommentRangeEnd',
 		'Text',
 		'Move',
-		'MoveRangeStart',
-		'MoveRangeEnd',
+		'MoveToRangeStart',
+		'MoveToRangeEnd',
+		'MoveFromRangeStart',
+		'MoveFromRangeEnd',
 		'Insertion',
 		'FootnoteReference',
 		this.name,

--- a/lib/components/track-changes/src/Insertion.ts
+++ b/lib/components/track-changes/src/Insertion.ts
@@ -22,8 +22,10 @@ import type { FootnoteReference } from '../../document/src/FootnoteReference.ts'
 import type { Text } from '../../document/src/Text.ts';
 import type { Deletion } from './Deletion.ts';
 import type { Move } from './Move.ts';
-import type { MoveRangeEnd } from './MoveRangeEnd.ts';
-import type { MoveRangeStart } from './MoveRangeStart.ts';
+import type { MoveFromRangeEnd } from './MoveFromRangeEnd.ts';
+import type { MoveFromRangeStart } from './MoveFromRangeStart.ts';
+import type { MoveToRangeEnd } from './MoveToRangeEnd.ts';
+import type { MoveToRangeStart } from './MoveToRangeStart.ts';
 
 /**
  * A type specifying the children of {@link Insertion}.
@@ -36,8 +38,10 @@ export type InsertionChild =
 	| Text
 	| Move
 	| Insertion
-	| MoveRangeStart
-	| MoveRangeEnd
+	| MoveToRangeStart
+	| MoveToRangeEnd
+	| MoveFromRangeStart
+	| MoveFromRangeEnd
 	| Deletion
 	| FootnoteReference;
 
@@ -64,8 +68,10 @@ export class Insertion extends Component<InsertionProps, InsertionChild> {
 		'CommentRangeEnd',
 		'Text',
 		'Move',
-		'MoveRangeStart',
-		'MoveRangeEnd',
+		'MoveToRangeStart',
+		'MoveToRangeEnd',
+		'MoveFromRangeStart',
+		'MoveFromRangeEnd',
 		'Deletion',
 		'FootnoteReference',
 		this.name,

--- a/lib/components/track-changes/src/Move.ts
+++ b/lib/components/track-changes/src/Move.ts
@@ -22,8 +22,10 @@ import type { FootnoteReference } from '../../document/src/FootnoteReference.ts'
 import type { Text } from '../../document/src/Text.ts';
 import type { Deletion } from './Deletion.ts';
 import type { Insertion } from './Insertion.ts';
-import type { MoveRangeEnd } from './MoveRangeEnd.ts';
-import type { MoveRangeStart } from './MoveRangeStart.ts';
+import type { MoveFromRangeEnd } from './MoveFromRangeEnd.ts';
+import type { MoveFromRangeStart } from './MoveFromRangeStart.ts';
+import type { MoveToRangeEnd } from './MoveToRangeEnd.ts';
+import type { MoveToRangeStart } from './MoveToRangeStart.ts';
 
 /**
  * A type specifying the children of {@link Move}.
@@ -35,8 +37,10 @@ export type MoveChild =
 	| CommentRangeEnd
 	| Text
 	| Move
-	| MoveRangeStart
-	| MoveRangeEnd
+	| MoveToRangeStart
+	| MoveToRangeEnd
+	| MoveFromRangeStart
+	| MoveFromRangeEnd
 	| Insertion
 	| Deletion
 	| FootnoteReference;
@@ -62,8 +66,10 @@ export class Move extends Component<MoveProps, MoveChild> {
 		'CommentRangeStart',
 		'CommentRangeEnd',
 		'Text',
-		'MoveRangeStart',
-		'MoveRangeEnd',
+		'MoveToRangeStart',
+		'MoveToRangeEnd',
+		'MoveFromRangeStart',
+		'MoveFromRangeEnd',
 		'Insertion',
 		'Deletion',
 		'FootnoteReference',

--- a/lib/components/track-changes/src/MoveFromRangeEnd.ts
+++ b/lib/components/track-changes/src/MoveFromRangeEnd.ts
@@ -15,14 +15,14 @@ export type MoveFromRangeEndProps = {
 };
 
 /**
- * A type for indicating the end of a range of content that was moved from one place to another.
+ * A type for indicating the end of a range of content that was moved from one place to another .
  * In OOXML, these are self-closing tags.
  */
 export class MoveFromRangeEnd extends Component<
 	MoveFromRangeEndProps,
 	MoveFromRangeEndChild
 > {
-	public static override readonly children: string[] = [];
+	// public static override readonly children: string[] = [];
 	public static override readonly mixed: boolean = false;
 
 	/**
@@ -45,9 +45,11 @@ export class MoveFromRangeEnd extends Component<
 	 * Asserts whether or not a given XML node correlates with this component.
 	 */
 	static override matchesNode(node: Node): boolean {
-		return node.nodeName === `${QNS.w}moveFromRangeEnd`;
+		return (
+			`Q{${(node as Element).namespaceURI}}` === QNS.w &&
+			(node as Element).localName === `moveFromRangeEnd`
+		);
 	}
-
 	/**
 	 * Instantiate this component from the XML in an existing DOCX file.
 	 */

--- a/lib/components/track-changes/src/MoveFromRangeEnd.ts
+++ b/lib/components/track-changes/src/MoveFromRangeEnd.ts
@@ -8,20 +8,19 @@ import { create } from '../../../utilities/src/dom.ts';
 import { QNS } from '../../../utilities/src/namespaces.ts';
 import { evaluateXPathToMap } from '../../../utilities/src/xquery.ts';
 
-export type MoveRangeEndChild = never;
+export type MoveFromRangeEndChild = never;
 
-export type MoveRangeEndProps = {
+export type MoveFromRangeEndProps = {
 	id: number;
-	type: 'from' | 'to';
 };
 
 /**
  * A type for indicating the end of a range of moved content.
  * In OOXML, these are self-closing tags.
  */
-export class MoveRangeEnd extends Component<
-	MoveRangeEndProps,
-	MoveRangeEndChild
+export class MoveFromRangeEnd extends Component<
+	MoveFromRangeEndProps,
+	MoveFromRangeEndChild
 > {
 	public static override readonly children: string[] = [];
 	public static override readonly mixed: boolean = false;
@@ -32,19 +31,11 @@ export class MoveRangeEnd extends Component<
 	public override toNode(): Node {
 		return create(
 			`
-				switch ($type)
-				case 'to' return 
-				element ${QNS.w}moveToRangeEnd {
-					attribute ${QNS.w}id { $id }
-				}
-				case 'from' return 
 				element ${QNS.w}moveFromRangeEnd { 
 					attribute ${QNS.w}id { $id }
 				}
-				default return ()
 			`,
 			{
-				type: this.props.type,
 				id: this.props.id,
 			}
 		);
@@ -54,17 +45,13 @@ export class MoveRangeEnd extends Component<
 	 * Asserts whether or not a given XML node correlates with this component.
 	 */
 	static override matchesNode(node: Node): boolean {
-		return (
-			node.nodeName === 'w:moveFromRangeEnd' ||
-			node.nodeName === 'w:moveToRangeEnd'
-		);
+		return node.nodeName === 'w:moveFromRangeEnd';
 	}
 
 	/**
 	 * Instantiate this component from the XML in an existing DOCX file.
 	 */
-	static override fromNode(node: Node): MoveRangeEnd {
-		const type = node.nodeName === 'w:moveFromRangeEnd' ? 'from' : 'to';
+	static override fromNode(node: Node): MoveFromRangeEnd {
 		const { id } = evaluateXPathToMap<{
 			id: number;
 		}>(
@@ -73,11 +60,10 @@ export class MoveRangeEnd extends Component<
 			}`,
 			node
 		);
-		return new MoveRangeEnd({
-			type: type,
+		return new MoveFromRangeEnd({
 			id: id,
 		});
 	}
 }
 
-registerComponent(MoveRangeEnd);
+registerComponent(MoveFromRangeEnd);

--- a/lib/components/track-changes/src/MoveFromRangeEnd.ts
+++ b/lib/components/track-changes/src/MoveFromRangeEnd.ts
@@ -15,7 +15,7 @@ export type MoveFromRangeEndProps = {
 };
 
 /**
- * A type for indicating the end of a range of moved content.
+ * A type for indicating the end of a range of content that was moved from one place to another.
  * In OOXML, these are self-closing tags.
  */
 export class MoveFromRangeEnd extends Component<
@@ -45,7 +45,7 @@ export class MoveFromRangeEnd extends Component<
 	 * Asserts whether or not a given XML node correlates with this component.
 	 */
 	static override matchesNode(node: Node): boolean {
-		return node.nodeName === 'w:moveFromRangeEnd';
+		return node.nodeName === `${QNS.w}moveFromRangeEnd`;
 	}
 
 	/**

--- a/lib/components/track-changes/src/MoveFromRangeStart.ts
+++ b/lib/components/track-changes/src/MoveFromRangeStart.ts
@@ -1,0 +1,81 @@
+// Import without assignment ensures Deno does not tree-shake this component. To avoid circular
+// definitions, components register themselves in a side-effect of their module.
+import '../../document/src/Text.ts';
+
+import { Component } from '../../../classes/src/Component.ts';
+import type { ChangeInformation } from '../../../utilities/src/changes.ts';
+import { registerComponent } from '../../../utilities/src/components.ts';
+import { create } from '../../../utilities/src/dom.ts';
+import { QNS } from '../../../utilities/src/namespaces.ts';
+import { evaluateXPathToMap } from '../../../utilities/src/xquery.ts';
+
+export type MoveFromRangeStartProps = ChangeInformation & {
+	name: string;
+};
+
+export type MoveRangeStartChild = never;
+
+/**
+ * A type for indicating the start of a range of moved content.
+ * In OOXML, these are self-closing tags.
+ */
+export class MoveFromRangeStart extends Component<
+	MoveFromRangeStartProps,
+	MoveRangeStartChild
+> {
+	/**
+	 * Creates an XML DOM node for this component instance.
+	 */
+	public override toNode(): Node {
+		return create(
+			` 
+				element ${QNS.w}moveFromRangeStart {
+					attribute ${QNS.w}id { $id }, 
+					if ($date) then attribute ${QNS.w}date { $date } else (),
+					if ($author) then attribute ${QNS.w}author { $author } else (),
+					attribute ${QNS.w}name { $name }
+				}
+			`,
+			{
+				...this.props,
+				author: this.props.author ? this.props.author : null,
+				date: this.props.date ? this.props.date.toISOString() : null,
+			}
+		);
+	}
+
+	/**
+	 * Asserts whether or not a given XML node correlates with this component.
+	 */
+	static override matchesNode(node: Node): boolean {
+		return node.nodeName === 'w:moveFromRangeStart';
+	}
+
+	/**
+	 * Instantiate this component from the XML in an existing DOCX file.
+	 */
+	static override fromNode(node: Node): MoveFromRangeStart {
+		const { id, name, date, author } = evaluateXPathToMap<{
+			id: number;
+			name: string;
+			date?: Date;
+			author?: string;
+		}>(
+			`map { 
+				"id": ./@${QNS.w}id/number(), 
+				"name": ./@${QNS.w}name/string(),
+				"date": ./@${QNS.w}date/string(),
+				"author": ./@${QNS.w}author/string()
+			}`,
+			node
+		);
+		return new MoveFromRangeStart({
+			id: id,
+			name: name,
+			date: date ? new Date(date) : undefined,
+			author: author ? author : undefined,
+		});
+	}
+}
+
+registerComponent(MoveFromRangeStart);

--- a/lib/components/track-changes/src/MoveFromRangeStart.ts
+++ b/lib/components/track-changes/src/MoveFromRangeStart.ts
@@ -16,7 +16,7 @@ export type MoveFromRangeStartProps = ChangeInformation & {
 export type MoveFromRangeStartChild = never;
 
 /**
- * A type for indicating the start of a range of content that was moved from one place to another. 
+ * A type for indicating the start of a range of content that was moved from one place to another.
  * In OOXML, these are self-closing tags.
  */
 export class MoveFromRangeStart extends Component<
@@ -48,7 +48,10 @@ export class MoveFromRangeStart extends Component<
 	 * Asserts whether or not a given XML node correlates with this component.
 	 */
 	static override matchesNode(node: Node): boolean {
-		return node.nodeName === `${QNS.w}moveFromRangeStart`;
+		return (
+			`Q{${(node as Element).namespaceURI}}` === QNS.w &&
+			(node as Element).localName === `moveFromRangeStart`
+		);
 	}
 
 	/**

--- a/lib/components/track-changes/src/MoveFromRangeStart.ts
+++ b/lib/components/track-changes/src/MoveFromRangeStart.ts
@@ -13,7 +13,7 @@ export type MoveFromRangeStartProps = ChangeInformation & {
 	name: string;
 };
 
-export type MoveRangeStartChild = never;
+export type MoveFromRangeStartChild = never;
 
 /**
  * A type for indicating the start of a range of moved content.
@@ -21,7 +21,7 @@ export type MoveRangeStartChild = never;
  */
 export class MoveFromRangeStart extends Component<
 	MoveFromRangeStartProps,
-	MoveRangeStartChild
+	MoveFromRangeStartChild
 > {
 	/**
 	 * Creates an XML DOM node for this component instance.

--- a/lib/components/track-changes/src/MoveFromRangeStart.ts
+++ b/lib/components/track-changes/src/MoveFromRangeStart.ts
@@ -16,7 +16,7 @@ export type MoveFromRangeStartProps = ChangeInformation & {
 export type MoveFromRangeStartChild = never;
 
 /**
- * A type for indicating the start of a range of moved content.
+ * A type for indicating the start of a range of content that was moved from one place to another. 
  * In OOXML, these are self-closing tags.
  */
 export class MoveFromRangeStart extends Component<
@@ -48,7 +48,7 @@ export class MoveFromRangeStart extends Component<
 	 * Asserts whether or not a given XML node correlates with this component.
 	 */
 	static override matchesNode(node: Node): boolean {
-		return node.nodeName === 'w:moveFromRangeStart';
+		return node.nodeName === `${QNS.w}moveFromRangeStart`;
 	}
 
 	/**

--- a/lib/components/track-changes/src/MoveToRangeEnd.ts
+++ b/lib/components/track-changes/src/MoveToRangeEnd.ts
@@ -1,0 +1,69 @@
+// Import without assignment ensures Deno does not tree-shake this component. To avoid circular
+// definitions, components register themselves in a side-effect of their module.
+import '../../document/src/Text.ts';
+
+import { Component } from '../../../classes/src/Component.ts';
+import { registerComponent } from '../../../utilities/src/components.ts';
+import { create } from '../../../utilities/src/dom.ts';
+import { QNS } from '../../../utilities/src/namespaces.ts';
+import { evaluateXPathToMap } from '../../../utilities/src/xquery.ts';
+
+export type MoveRangeEndChild = never;
+
+export type MoveToRangeEndProps = {
+	id: number;
+};
+
+/**
+ * A type for indicating the end of a range of moved content.
+ * In OOXML, these are self-closing tags.
+ */
+export class MoveToRangeEnd extends Component<
+	MoveToRangeEndProps,
+	MoveRangeEndChild
+> {
+	public static override readonly children: string[] = [];
+	public static override readonly mixed: boolean = false;
+
+	/**
+	 * Creates an XML DOM node for this component instance.
+	 */
+	public override toNode(): Node {
+		return create(
+			`
+				element ${QNS.w}moveToRangeEnd {
+					attribute ${QNS.w}id { $id }
+				}
+			`,
+			{
+				id: this.props.id,
+			}
+		);
+	}
+
+	/**
+	 * Asserts whether or not a given XML node correlates with this component.
+	 */
+	static override matchesNode(node: Node): boolean {
+		return node.nodeName === 'w:moveToRangeEnd';
+	}
+
+	/**
+	 * Instantiate this component from the XML in an existing DOCX file.
+	 */
+	static override fromNode(node: Node): MoveToRangeEnd {
+		const { id } = evaluateXPathToMap<{
+			id: number;
+		}>(
+			`map { 
+				"id": ./@${QNS.w}id/number()
+			}`,
+			node
+		);
+		return new MoveToRangeEnd({
+			id: id,
+		});
+	}
+}
+
+registerComponent(MoveToRangeEnd);

--- a/lib/components/track-changes/src/MoveToRangeEnd.ts
+++ b/lib/components/track-changes/src/MoveToRangeEnd.ts
@@ -15,7 +15,7 @@ export type MoveToRangeEndProps = {
 };
 
 /**
- * A type for indicating the end of a range of content that was moved to one place from elsewhere. 
+ * A type for indicating the end of a range of content that was moved to one place from elsewhere.
  * In OOXML, these are self-closing tags.
  */
 export class MoveToRangeEnd extends Component<
@@ -45,7 +45,10 @@ export class MoveToRangeEnd extends Component<
 	 * Asserts whether or not a given XML node correlates with this component.
 	 */
 	static override matchesNode(node: Node): boolean {
-		return node.nodeName === `${QNS.w}moveToRangeEnd`;
+		return (
+			`Q{${(node as Element).namespaceURI}}` === QNS.w &&
+			(node as Element).localName === `moveToRangeEnd`
+		);
 	}
 
 	/**

--- a/lib/components/track-changes/src/MoveToRangeEnd.ts
+++ b/lib/components/track-changes/src/MoveToRangeEnd.ts
@@ -15,7 +15,7 @@ export type MoveToRangeEndProps = {
 };
 
 /**
- * A type for indicating the end of a range of moved content.
+ * A type for indicating the end of a range of content that was moved to one place from elsewhere. 
  * In OOXML, these are self-closing tags.
  */
 export class MoveToRangeEnd extends Component<
@@ -45,7 +45,7 @@ export class MoveToRangeEnd extends Component<
 	 * Asserts whether or not a given XML node correlates with this component.
 	 */
 	static override matchesNode(node: Node): boolean {
-		return node.nodeName === 'w:moveToRangeEnd';
+		return node.nodeName === `${QNS.w}moveToRangeEnd`;
 	}
 
 	/**

--- a/lib/components/track-changes/src/MoveToRangeStart.ts
+++ b/lib/components/track-changes/src/MoveToRangeStart.ts
@@ -13,7 +13,7 @@ export type MoveToRangeStartProps = ChangeInformation & {
 	name: string;
 };
 
-export type MoveRangeStartChild = never;
+export type MoveToRangeStartChild = never;
 
 /**
  * A type for indicating the start of a range of moved content.
@@ -21,7 +21,7 @@ export type MoveRangeStartChild = never;
  */
 export class MoveToRangeStart extends Component<
 	MoveToRangeStartProps,
-	MoveRangeStartChild
+	MoveToRangeStartChild
 > {
 	/**
 	 * Creates an XML DOM node for this component instance.

--- a/lib/components/track-changes/src/MoveToRangeStart.ts
+++ b/lib/components/track-changes/src/MoveToRangeStart.ts
@@ -9,9 +9,8 @@ import { create } from '../../../utilities/src/dom.ts';
 import { QNS } from '../../../utilities/src/namespaces.ts';
 import { evaluateXPathToMap } from '../../../utilities/src/xquery.ts';
 
-export type MoveRangeStartProps = ChangeInformation & {
+export type MoveToRangeStartProps = ChangeInformation & {
 	name: string;
-	type: 'from' | 'to';
 };
 
 export type MoveRangeStartChild = never;
@@ -20,8 +19,8 @@ export type MoveRangeStartChild = never;
  * A type for indicating the start of a range of moved content.
  * In OOXML, these are self-closing tags.
  */
-export class MoveRangeStart extends Component<
-	MoveRangeStartProps,
+export class MoveToRangeStart extends Component<
+	MoveToRangeStartProps,
 	MoveRangeStartChild
 > {
 	/**
@@ -29,24 +28,13 @@ export class MoveRangeStart extends Component<
 	 */
 	public override toNode(): Node {
 		return create(
-			`	let $attrs := [
+			`
+				element ${QNS.w}moveToRangeStart {
 					attribute ${QNS.w}id { $id }, 
 					if ($date) then attribute ${QNS.w}date { $date } else (),
 					if ($author) then attribute ${QNS.w}author { $author } else (),
 					attribute ${QNS.w}name { $name }
-				]
-				return (
-					switch ($type)
-					case 'to' return 
-					element ${QNS.w}moveToRangeStart {
-						$attrs
-					}
-					case 'from' return 
-					element ${QNS.w}moveFromRangeStart {
-						$attrs
-					}
-					default return ()
-				)	
+				}
 			`,
 			{
 				...this.props,
@@ -60,17 +48,13 @@ export class MoveRangeStart extends Component<
 	 * Asserts whether or not a given XML node correlates with this component.
 	 */
 	static override matchesNode(node: Node): boolean {
-		return (
-			node.nodeName === 'w:moveFromRangeStart' ||
-			node.nodeName === 'w:moveToRangeStart'
-		);
+		return node.nodeName === 'w:moveToRangeStart';
 	}
 
 	/**
 	 * Instantiate this component from the XML in an existing DOCX file.
 	 */
-	static override fromNode(node: Node): MoveRangeStart {
-		const type = node.nodeName === 'w:moveFromRangeStart' ? 'from' : 'to';
+	static override fromNode(node: Node): MoveToRangeStart {
 		const { id, name, date, author } = evaluateXPathToMap<{
 			id: number;
 			name: string;
@@ -85,8 +69,7 @@ export class MoveRangeStart extends Component<
 			}`,
 			node
 		);
-		return new MoveRangeStart({
-			type: type,
+		return new MoveToRangeStart({
 			id: id,
 			name: name,
 			date: date ? new Date(date) : undefined,
@@ -95,4 +78,4 @@ export class MoveRangeStart extends Component<
 	}
 }
 
-registerComponent(MoveRangeStart);
+registerComponent(MoveToRangeStart);

--- a/lib/components/track-changes/src/MoveToRangeStart.ts
+++ b/lib/components/track-changes/src/MoveToRangeStart.ts
@@ -16,7 +16,7 @@ export type MoveToRangeStartProps = ChangeInformation & {
 export type MoveToRangeStartChild = never;
 
 /**
- * A type for indicating the start of a range of moved content.
+ * A type for indicating the start of a range of content that was moved to one place from elsewhere.
  * In OOXML, these are self-closing tags.
  */
 export class MoveToRangeStart extends Component<
@@ -48,7 +48,7 @@ export class MoveToRangeStart extends Component<
 	 * Asserts whether or not a given XML node correlates with this component.
 	 */
 	static override matchesNode(node: Node): boolean {
-		return node.nodeName === 'w:moveToRangeStart';
+		return node.nodeName === `${QNS.w}moveToRangeStart`;
 	}
 
 	/**

--- a/lib/components/track-changes/src/MoveToRangeStart.ts
+++ b/lib/components/track-changes/src/MoveToRangeStart.ts
@@ -48,7 +48,10 @@ export class MoveToRangeStart extends Component<
 	 * Asserts whether or not a given XML node correlates with this component.
 	 */
 	static override matchesNode(node: Node): boolean {
-		return node.nodeName === `${QNS.w}moveToRangeStart`;
+		return (
+			`Q{${(node as Element).namespaceURI}}` === QNS.w &&
+			(node as Element).localName === `moveToRangeStart`
+		);
 	}
 
 	/**

--- a/lib/components/track-changes/test/Deletion.test.ts
+++ b/lib/components/track-changes/test/Deletion.test.ts
@@ -453,7 +453,7 @@ describe('Deletion', () => {
 			});
 		});
 
-		describe('MoveRangeStart and MoveRangeEnd', () => {
+		describe('MoveToRangeStart, MoveToRangeEnd, MoveFromRangeStart, MoveFromRangeEnd', () => {
 			const deletedMoveRangeToNode = create(
 				`<w:p xmlns:w="${NamespaceUri.w}">
 					<w:del w:id="1" w:author="Luis" w:date="${date.toISOString()}">

--- a/lib/components/track-changes/test/Deletion.test.ts
+++ b/lib/components/track-changes/test/Deletion.test.ts
@@ -11,10 +11,12 @@ import { BookmarkRangeEnd } from '../../document/src/BookmarkRangeEnd.ts';
 import { BookmarkRangeStart } from '../../document/src/BookmarkRangeStart.ts';
 import { Paragraph } from '../../document/src/Paragraph.ts';
 import { Text } from '../../document/src/Text.ts';
+import { MoveFromRangeEnd } from '../../track-changes/src/MoveFromRangeEnd.ts';
+import { MoveFromRangeStart } from '../../track-changes/src/MoveFromRangeStart.ts';
+import { MoveToRangeEnd } from '../../track-changes/src/MoveToRangeEnd.ts';
+import { MoveToRangeStart } from '../../track-changes/src/MoveToRangeStart.ts';
 import { Deletion } from '../src/Deletion.ts';
 import { Move } from '../src/Move.ts';
-import { MoveRangeEnd } from '../src/MoveRangeEnd.ts';
-import { MoveRangeStart } from '../src/MoveRangeStart.ts';
 
 describe('Deletion', () => {
 	const date = new Date();
@@ -471,27 +473,23 @@ describe('Deletion', () => {
 
 			const deletedMoveRange = new Deletion(
 				{ author: 'Luis', date: date, id: 1 },
-				new MoveRangeStart({
+				new MoveToRangeStart({
 					id: 0,
 					date: date,
 					author: 'Gabe',
-					type: 'to',
 					name: 'Move_to_1',
 				}),
-				new MoveRangeEnd({
+				new MoveToRangeEnd({
 					id: 0,
-					type: 'to',
 				}),
-				new MoveRangeStart({
+				new MoveFromRangeStart({
 					id: 1,
 					date: date,
 					author: 'Angel',
-					type: 'from',
 					name: 'Move_from_1',
 				}),
-				new MoveRangeEnd({
+				new MoveFromRangeEnd({
 					id: 1,
-					type: 'from',
 				})
 			);
 

--- a/lib/components/track-changes/test/Insertion.test.ts
+++ b/lib/components/track-changes/test/Insertion.test.ts
@@ -14,8 +14,10 @@ import { Archive } from '../../../classes/src/Archive.ts';
 import type { ComponentContext } from '../../../classes/src/Component.ts';
 import { create, serialize } from '../../../utilities/src/dom.ts';
 import { NamespaceUri } from '../../../utilities/src/namespaces.ts';
-import { MoveRangeEnd } from '../src/MoveRangeEnd.ts';
-import { MoveRangeStart } from '../src/MoveRangeStart.ts';
+import { MoveFromRangeEnd } from '../src/MoveFromRangeEnd.ts';
+import { MoveFromRangeStart } from '../src/MoveFromRangeStart.ts';
+import { MoveToRangeEnd } from '../src/MoveToRangeEnd.ts';
+import { MoveToRangeStart } from '../src/MoveToRangeStart.ts';
 
 describe('Insertion', () => {
 	const date = new Date();
@@ -412,27 +414,23 @@ describe('Insertion', () => {
 
 			const insertedMoveRange = new Insertion(
 				{ author: 'Luis', date: date, id: 1 },
-				new MoveRangeStart({
+				new MoveToRangeStart({
 					id: 0,
 					date: date,
 					author: 'Gabe',
-					type: 'to',
 					name: 'Move_to_1',
 				}),
-				new MoveRangeEnd({
+				new MoveToRangeEnd({
 					id: 0,
-					type: 'to',
 				}),
-				new MoveRangeStart({
+				new MoveFromRangeStart({
 					id: 1,
 					date: date,
 					author: 'Angel',
-					type: 'from',
 					name: 'Move_from_1',
 				}),
-				new MoveRangeEnd({
+				new MoveFromRangeEnd({
 					id: 1,
-					type: 'from',
 				})
 			);
 

--- a/lib/components/track-changes/test/MoveRangeEnd.test.ts
+++ b/lib/components/track-changes/test/MoveRangeEnd.test.ts
@@ -3,30 +3,28 @@ import { describe, it } from 'std/testing/bdd';
 
 import { create, serialize } from '../../../utilities/src/dom.ts';
 import { NamespaceUri } from '../../../utilities/src/namespaces.ts';
-import { MoveRangeEnd } from '../src/MoveRangeEnd.ts';
+import { MoveFromRangeEnd } from '../src/MoveFromRangeEnd.ts';
+import { MoveToRangeEnd } from '../src/MoveToRangeEnd.ts';
 
 describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
-	const moveToRangeEnd = MoveRangeEnd.fromNode(
+	const moveToRangeEnd = MoveToRangeEnd.fromNode(
 		create(`<w:moveToRangeEnd xmlns:w="${NamespaceUri.w}" w:id="0" />`)
 	);
 
-	const moveFromRangeEnd = MoveRangeEnd.fromNode(
+	const moveFromRangeEnd = MoveFromRangeEnd.fromNode(
 		create(`<w:moveFromRangeEnd xmlns:w="${NamespaceUri.w}" w:id="1" />`)
 	);
 	it('Create MoveToRangeEnd from node', () => {
 		expect(moveToRangeEnd.props.id).toBe(0);
-		expect(moveToRangeEnd.props.type).toBe('to');
 	});
 
 	it('Create MoveFromRangeEnd from node', () => {
 		expect(moveFromRangeEnd.props.id).toBe(1);
-		expect(moveFromRangeEnd.props.type).toBe('from');
 	});
 
 	it('Create MoveToRangeEnd node from MoveRangeEnd object', () => {
-		const toRangeObject = new MoveRangeEnd({
+		const toRangeObject = new MoveToRangeEnd({
 			id: 2,
-			type: 'to',
 		});
 
 		expect(serialize(toRangeObject.toNode())).toBe(
@@ -37,9 +35,8 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 			)
 		);
 
-		const fromRangeObject = new MoveRangeEnd({
+		const fromRangeObject = new MoveFromRangeEnd({
 			id: 3,
-			type: 'from',
 		});
 		expect(serialize(fromRangeObject.toNode())).toBe(
 			serialize(

--- a/lib/components/track-changes/test/MoveRangeStart.test.ts
+++ b/lib/components/track-changes/test/MoveRangeStart.test.ts
@@ -1,7 +1,8 @@
 import { expect } from 'std/expect';
 import { describe, it } from 'std/testing/bdd';
 
-import { MoveRangeStart } from '../../track-changes/src/MoveRangeStart.ts';
+import { MoveFromRangeStart } from '../src/MoveFromRangeStart.ts';
+import { MoveToRangeStart } from '../src/MoveToRangeStart.ts';
 
 import { create, serialize } from '../../../utilities/src/dom.ts';
 import { NamespaceUri } from '../../../utilities/src/namespaces.ts';
@@ -10,7 +11,7 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 	const date = new Date();
 
 	it('Create MoveToRangeStart from node', () => {
-		const moveToRangeStart = MoveRangeStart.fromNode(
+		const moveToRangeStart = MoveToRangeStart.fromNode(
 			create(
 				`<w:moveToRangeStart xmlns:w="${
 					NamespaceUri.w
@@ -21,11 +22,10 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 		expect(moveToRangeStart.props.date).toEqual(date);
 		expect(moveToRangeStart.props.id).toBe(0);
 		expect(moveToRangeStart.props.name).toBe('Move_to_1');
-		expect(moveToRangeStart.props.type).toBe('to');
 	});
 
 	it('Create MoveToRangeStart without author from node', () => {
-		const moveToRangeStartWithoutAuthor = MoveRangeStart.fromNode(
+		const moveToRangeStartWithoutAuthor = MoveToRangeStart.fromNode(
 			create(
 				`<w:moveToRangeStart xmlns:w="${
 					NamespaceUri.w
@@ -36,11 +36,10 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 		expect(moveToRangeStartWithoutAuthor.props.date).toEqual(date);
 		expect(moveToRangeStartWithoutAuthor.props.id).toBe(1);
 		expect(moveToRangeStartWithoutAuthor.props.name).toBe('Move_to_1');
-		expect(moveToRangeStartWithoutAuthor.props.type).toBe('to');
 	});
 
 	it('Create MoveToRangeStart without date from node', () => {
-		const moveToRangeStartWithoutDate = MoveRangeStart.fromNode(
+		const moveToRangeStartWithoutDate = MoveToRangeStart.fromNode(
 			create(
 				`<w:moveToRangeStart xmlns:w="${NamespaceUri.w}" w:id="1" w:author="Angel" w:name="Move_to_1" />`
 			)
@@ -49,23 +48,21 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 		expect(moveToRangeStartWithoutDate.props.date).toBe(undefined);
 		expect(moveToRangeStartWithoutDate.props.id).toBe(1);
 		expect(moveToRangeStartWithoutDate.props.name).toBe('Move_to_1');
-		expect(moveToRangeStartWithoutDate.props.type).toBe('to');
 	});
 
 	it('Create MoveFromRangeStart from node', () => {
-		const moveFromRangeStart = MoveRangeStart.fromNode(
+		const moveFromRangeStart = MoveFromRangeStart.fromNode(
 			create(
 				`<w:moveFromRangeStart xmlns:w="${
 					NamespaceUri.w
 				}" w:id="1" w:date="${date.toISOString()}" w:author="Angel" w:name="Move_from_1" />`
 			)
 		);
-		expect(moveFromRangeStart.props.type).toBe('from');
 		expect(moveFromRangeStart.props.author).toBe('Angel');
 	});
 
 	it('Create MoveFromRangeStart without author from node', () => {
-		const moveFromRangeStartWithoutAuthor = MoveRangeStart.fromNode(
+		const moveFromRangeStartWithoutAuthor = MoveFromRangeStart.fromNode(
 			create(
 				`<w:moveFromRangeStart xmlns:w="${
 					NamespaceUri.w
@@ -76,11 +73,10 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 		expect(moveFromRangeStartWithoutAuthor.props.date).toEqual(date);
 		expect(moveFromRangeStartWithoutAuthor.props.id).toBe(1);
 		expect(moveFromRangeStartWithoutAuthor.props.name).toBe('Move_from_1');
-		expect(moveFromRangeStartWithoutAuthor.props.type).toBe('from');
 	});
 
 	it('Create MoveFromRangeStart without date from node', () => {
-		const moveFromRangeStartWithoutDate = MoveRangeStart.fromNode(
+		const moveFromRangeStartWithoutDate = MoveFromRangeStart.fromNode(
 			create(
 				`<w:moveFromRangeStart xmlns:w="${NamespaceUri.w}" w:id="1" w:author="Angel" w:name="Move_from_1" />`
 			)
@@ -89,15 +85,13 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 		expect(moveFromRangeStartWithoutDate.props.date).toBe(undefined);
 		expect(moveFromRangeStartWithoutDate.props.id).toBe(1);
 		expect(moveFromRangeStartWithoutDate.props.name).toBe('Move_from_1');
-		expect(moveFromRangeStartWithoutDate.props.type).toBe('from');
 	});
 
 	it('Create MoveToRangeStart node from MoveRangeStart object', () => {
-		const toRangeObject = new MoveRangeStart({
+		const toRangeObject = new MoveToRangeStart({
 			id: 2,
 			date: date,
 			author: 'Gabe',
-			type: 'to',
 			name: 'To_Range_Object',
 		});
 
@@ -113,11 +107,10 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 	});
 
 	it('Create MoveFromRangeStart node from MoveRangeStart object', () => {
-		const toRangeObject = new MoveRangeStart({
+		const toRangeObject = new MoveFromRangeStart({
 			id: 3,
 			date: date,
 			author: 'Angel',
-			type: 'from',
 			name: 'From_Range_Object',
 		});
 
@@ -133,9 +126,8 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 	});
 
 	it('Create MoveFromRangeStart node MoveRangeStart from object without author and date parameters', () => {
-		const toRangeObject = new MoveRangeStart({
+		const toRangeObject = new MoveFromRangeStart({
 			id: 3,
-			type: 'from',
 			name: 'From_Range_Object',
 		});
 
@@ -149,9 +141,8 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 	});
 
 	it('Create MoveFromRangeStart node MoveRangeStart from object without author parameter', () => {
-		const toRangeObject = new MoveRangeStart({
+		const toRangeObject = new MoveFromRangeStart({
 			id: 3,
-			type: 'from',
 			name: 'From_Range_Object',
 			author: 'Angel',
 		});
@@ -166,9 +157,8 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 	});
 
 	it('Create MoveFromRangeStart node MoveRangeStart from object without date parameter', () => {
-		const toRangeObject = new MoveRangeStart({
+		const toRangeObject = new MoveFromRangeStart({
 			id: 3,
-			type: 'from',
 			name: 'From_Range_Object',
 			date: date,
 		});
@@ -185,9 +175,8 @@ describe('MoveToRangeStart and MoveFromRangeStart elements...', () => {
 	});
 
 	it('Create MoveToRangeStart node MoveRangeStart from object without date parameter', () => {
-		const toRangeObject = new MoveRangeStart({
+		const toRangeObject = new MoveToRangeStart({
 			id: 3,
-			type: 'to',
 			name: 'To_Range_Object',
 			date: date,
 		});

--- a/mod.ts
+++ b/mod.ts
@@ -141,15 +141,25 @@ export {
 	type MoveProps,
 } from './lib/components/track-changes/src/Move.ts';
 export {
-	MoveRangeEnd,
-	type MoveRangeEndChild,
-	type MoveRangeEndProps,
-} from './lib/components/track-changes/src/MoveRangeEnd.ts';
+	MoveFromRangeEnd,
+	type MoveFromRangeEndChild,
+	type MoveFromRangeEndProps,
+} from './lib/components/track-changes/src/MoveFromRangeEnd.ts';
 export {
-	MoveRangeStart,
-	type MoveRangeStartChild,
-	type MoveRangeStartProps,
-} from './lib/components/track-changes/src/MoveRangeStart.ts';
+	MoveFromRangeStart,
+	type MoveFromRangeStartChild,
+	type MoveFromRangeStartProps,
+} from './lib/components/track-changes/src/MoveFromRangeStart.ts';
+export {
+	MoveToRangeEnd,
+	type MoveRangeEndChild,
+	type MoveToRangeEndProps,
+} from './lib/components/track-changes/src/MoveToRangeEnd.ts';
+export {
+	MoveToRangeStart,
+	type MoveToRangeStartChild,
+	type MoveToRangeStartProps,
+} from './lib/components/track-changes/src/MoveToRangeStart.ts';
 export { FileMime } from './lib/enums.ts';
 
 // Shared properties


### PR DESCRIPTION
This PR splits the existing `moveRangeStart` and `moveRangeEnd` components to make it easier for Fonto Output to convert documents, and the result more closely mimics the structure of OOXML. 

Now we have: 
- `moveToRangeStart`
- `moveToRangeEnd`
- `moveFromRangeStart`
- `moveFromRangeEnd`