### PR TITLE
Split `move` component into `moveTo` and `moveFrom`

### DIFF
--- a/examples/track-changes/move/track-changes-move-image.tsx
+++ b/examples/track-changes/move/track-changes-move-image.tsx
@@ -2,11 +2,12 @@
 import Docx, {
 	cm,
 	Image,
-	Move,
+	MoveFrom,
 	MoveFromRangeEnd,
 	MoveFromRangeStart,
 	MoveToRangeEnd,
 	MoveToRangeStart,
+	MoveTo,
 	Paragraph,
 	Section,
 	Text,
@@ -25,7 +26,7 @@ await Docx.fromJsx(
 				author={author}
 				date={date}
 			/>
-			<Move id={12} type="to" author={author} date={date}>
+			<MoveTo id={12} author={author} date={date}>
 				<Text>
 					<Image
 						data={Deno.readFile('assets/oldPhoto.jpg')}
@@ -35,7 +36,7 @@ await Docx.fromJsx(
 						alt="Description"
 					/>
 				</Text>
-			</Move>
+			</MoveTo>
 			<MoveToRangeEnd id={11} />
 		</Paragraph>
 		<Paragraph>
@@ -51,7 +52,7 @@ await Docx.fromJsx(
 				author={author}
 				date={date}
 			/>
-			<Move id={9} type="from" author={author} date={date}>
+			<MoveFrom id={9} author={author} date={date}>
 				<Text>
 					<Image
 						data={Deno.readFile('assets/oldPhoto.jpg')}
@@ -61,7 +62,7 @@ await Docx.fromJsx(
 						alt="Description"
 					/>
 				</Text>
-			</Move>
+			</MoveFrom>
 			<MoveFromRangeEnd id={8} />
 		</Paragraph>
 	</Section>

--- a/examples/track-changes/move/track-changes-move-list.tsx
+++ b/examples/track-changes/move/track-changes-move-list.tsx
@@ -1,11 +1,12 @@
 /** @jsx  Docx.jsx */
 import Docx, {
 	cm,
-	Move,
+	MoveFrom,
 	MoveFromRangeEnd,
 	MoveFromRangeStart,
 	MoveToRangeEnd,
 	MoveToRangeStart,
+	MoveTo,
 	Paragraph,
 	Section,
 	Text,
@@ -58,7 +59,7 @@ await Docx.fromJsx(
 		<Paragraph
 			listItem={{ numbering, depth: 0 }}
 			pilcrow={{
-				move: { id: 26, type: 'to', author: author, date: date },
+				moveTo: { id: 26, author: author, date: date },
 			}}
 		>
 			<MoveToRangeStart
@@ -67,45 +68,45 @@ await Docx.fromJsx(
 				author={author}
 				date={date}
 			/>
-			<Move id={28} type="to" author={author} date={date}>
+			<MoveTo id={28} author={author} date={date}>
 				<Text>
 					The play is set in a house in Andalusia, shortly before the
 					Spanish Civil War.
 				</Text>
-			</Move>
+			</MoveTo>
 		</Paragraph>
 		<Paragraph
 			listItem={{ numbering, depth: 0 }}
 			pilcrow={{
-				move: { id: 29, type: 'to', author: author, date: date },
+				moveTo: { id: 29, author: author, date: date },
 			}}
 		>
-			<Move id={30} type="to" author={author} date={date}>
+			<MoveTo id={30} author={author} date={date}>
 				<Text>
 					Bernarda Alba imposes an eight-year mourning period after
 					her husband’s death.
 				</Text>
-			</Move>
+			</MoveTo>
 		</Paragraph>
 		<Paragraph
 			listItem={{ numbering, depth: 1 }}
 			pilcrow={{
-				move: { id: 31, type: 'to', author: author, date: date },
+				moveTo: { id: 31, author: author, date: date },
 			}}
 		>
-			<Move id={32} type="to" author={author} date={date}>
+			<MoveTo id={32} author={author} date={date}>
 				<Text>Uses mourning to control her daughters</Text>
-			</Move>
+			</MoveTo>
 		</Paragraph>
 		<Paragraph
 			listItem={{ numbering, depth: 2 }}
 			pilcrow={{
-				move: { id: 33, type: 'to', author: author, date: date },
+				moveTo: { id: 33, author: author, date: date },
 			}}
 		>
-			<Move id={34} type="to" author={author} date={date}>
+			<MoveTo id={34} author={author} date={date}>
 				<Text>No courtship or social contact allowed</Text>
-			</Move>
+			</MoveTo>
 		</Paragraph>
 		<MoveToRangeEnd id={27} />
 
@@ -117,7 +118,7 @@ await Docx.fromJsx(
 		<Paragraph
 			listItem={{ numbering, depth: 0 }}
 			pilcrow={{
-				move: { id: 17, type: 'from', author: author, date: date },
+				moveFrom: { id: 17, author: author, date: date },
 			}}
 		>
 			<MoveFromRangeStart
@@ -126,45 +127,45 @@ await Docx.fromJsx(
 				author={author}
 				date={date}
 			/>
-			<Move id={19} type="from" author={author} date={date}>
+			<MoveFrom id={19} author={author} date={date}>
 				<Text>
 					The play is set in a house in Andalusia, shortly before the
 					Spanish Civil War.
 				</Text>
-			</Move>
+			</MoveFrom>
 		</Paragraph>
 		<Paragraph
 			listItem={{ numbering, depth: 0 }}
 			pilcrow={{
-				move: { id: 20, type: 'from', author: author, date: date },
+				moveFrom: { id: 20, author: author, date: date },
 			}}
 		>
-			<Move id={21} type="from" author={author} date={date}>
+			<MoveFrom id={21} author={author} date={date}>
 				<Text>
 					Bernarda Alba imposes an eight-year mourning period after
 					her husband’s death.
 				</Text>
-			</Move>
+			</MoveFrom>
 		</Paragraph>
 		<Paragraph
 			listItem={{ numbering, depth: 1 }}
 			pilcrow={{
-				move: { id: 22, type: 'from', author: author, date: date },
+				moveFrom: { id: 22, author: author, date: date },
 			}}
 		>
-			<Move id={23} type="from" author={author} date={date}>
+			<MoveFrom id={23} author={author} date={date}>
 				<Text>Uses mourning to control her daughters</Text>
-			</Move>
+			</MoveFrom>
 		</Paragraph>
 		<Paragraph
 			listItem={{ numbering, depth: 2 }}
 			pilcrow={{
-				move: { id: 24, type: 'from', author: author, date: date },
+				moveFrom: { id: 24, author: author, date: date },
 			}}
 		>
-			<Move id={25} type="from" author={author} date={date}>
+			<MoveFrom id={25} author={author} date={date}>
 				<Text>No courtship or social contact allowed</Text>
-			</Move>
+			</MoveFrom>
 		</Paragraph>
 		<MoveFromRangeEnd id={18} />
 	</Section>

--- a/examples/track-changes/move/track-changes-move-paragraph.tsx
+++ b/examples/track-changes/move/track-changes-move-paragraph.tsx
@@ -1,8 +1,9 @@
 /** @jsx  Docx.jsx */
 import Docx, {
-	Move,
+	MoveFrom,
 	MoveFromRangeEnd,
 	MoveFromRangeStart,
+	MoveTo,
 	MoveToRangeEnd,
 	MoveToRangeStart,
 	Paragraph,
@@ -18,7 +19,7 @@ await Docx.fromJsx(
 		{/* Paragraph MoveFrom */}
 		<Paragraph
 			pilcrow={{
-				move: { id: 0, type: 'from', author: author, date: date },
+				moveFrom: { id: 0, author: author, date: date },
 			}}
 		>
 			<MoveFromRangeStart
@@ -27,7 +28,7 @@ await Docx.fromJsx(
 				author={author}
 				date={date}
 			/>
-			<Move id={2} type="from" author={author} date={date}>
+			<MoveFrom id={2} author={author} date={date}>
 				<Text>
 					The House of Bernarda Alba is a tragedy by Federico García
 					Lorca, set in a small, traditional Andalusian village in
@@ -38,7 +39,7 @@ await Docx.fromJsx(
 					(39), Magdalena (30), Amelia (27), Martirio (24), and Adela
 					(20).
 				</Text>
-			</Move>
+			</MoveFrom>
 			<MoveFromRangeEnd id={1} />
 		</Paragraph>
 		<Paragraph>
@@ -58,7 +59,7 @@ await Docx.fromJsx(
 		{/* Paragraph MoveTo */}
 		<Paragraph
 			pilcrow={{
-				move: { id: 3, type: 'to', author: author, date: date },
+				moveTo: { id: 3, author: author, date: date },
 			}}
 		>
 			<MoveToRangeStart
@@ -67,7 +68,7 @@ await Docx.fromJsx(
 				author={author}
 				date={date}
 			/>
-			<Move id={5} type="to" author={author} date={date}>
+			<MoveTo id={5} author={author} date={date}>
 				<Text>
 					The House of Bernarda Alba is a tragedy by Federico García
 					Lorca, set in a small, traditional Andalusian village in
@@ -78,7 +79,7 @@ await Docx.fromJsx(
 					(39), Magdalena (30), Amelia (27), Martirio (24), and Adela
 					(20).
 				</Text>
-			</Move>
+			</MoveTo>
 			<MoveToRangeEnd id={4} />
 		</Paragraph>
 		<Paragraph>

--- a/examples/track-changes/move/track-changes-move-table.tsx
+++ b/examples/track-changes/move/track-changes-move-table.tsx
@@ -1,11 +1,12 @@
 /** @jsx  Docx.jsx */
 import Docx, {
 	Cell,
-	Move,
+	MoveFrom,
 	MoveFromRangeEnd,
 	MoveFromRangeStart,
 	MoveToRangeEnd,
 	MoveToRangeStart,
+	MoveTo,
 	Paragraph,
 	Row,
 	Section,
@@ -24,9 +25,8 @@ await Docx.fromJsx(
 				<Cell>
 					<Paragraph
 						pilcrow={{
-							move: {
+							moveTo: {
 								id: 15,
-								type: 'to',
 								author: author,
 								date: date,
 							},
@@ -38,25 +38,24 @@ await Docx.fromJsx(
 							author={author}
 							date={date}
 						/>
-						<Move id={17} type="to" author={author} date={date}>
+						<MoveTo id={17} author={author} date={date}>
 							<Text> Author</Text>
-						</Move>
+						</MoveTo>
 					</Paragraph>
 				</Cell>
 				<Cell>
 					<Paragraph
 						pilcrow={{
-							move: {
+							moveTo: {
 								id: 45,
-								type: 'to',
 								author: author,
 								date: date,
 							},
 						}}
 					>
-						<Move id={46} type="to" author={author} date={date}>
+						<MoveTo id={46} author={author} date={date}>
 							<Text>Federico García Lorca</Text>
-						</Move>
+						</MoveTo>
 					</Paragraph>
 				</Cell>
 			</Row>
@@ -64,33 +63,31 @@ await Docx.fromJsx(
 				<Cell>
 					<Paragraph
 						pilcrow={{
-							move: {
+							moveTo: {
 								id: 47,
-								type: 'to',
 								author: author,
 								date: date,
 							},
 						}}
 					>
-						<Move id={48} type="to" author={author} date={date}>
+						<MoveTo id={48} author={author} date={date}>
 							<Text>Genre</Text>
-						</Move>
+						</MoveTo>
 					</Paragraph>
 				</Cell>
 				<Cell>
 					<Paragraph
 						pilcrow={{
-							move: {
+							moveTo: {
 								id: 49,
-								type: 'to',
 								author: author,
 								date: date,
 							},
 						}}
 					>
-						<Move id={50} type="to" author={author} date={date}>
+						<MoveTo id={50} author={author} date={date}>
 							<Text>Tragedy</Text>
-						</Move>
+						</MoveTo>
 					</Paragraph>
 				</Cell>
 			</Row>
@@ -98,36 +95,34 @@ await Docx.fromJsx(
 				<Cell>
 					<Paragraph
 						pilcrow={{
-							move: {
+							moveTo: {
 								id: 51,
-								type: 'to',
 								author: author,
 								date: date,
 							},
 						}}
 					>
-						<Move id={52} type="to" author={author} date={date}>
+						<MoveTo id={52} author={author} date={date}>
 							<Text>Message</Text>
-						</Move>
+						</MoveTo>
 					</Paragraph>
 				</Cell>
 				<Cell>
 					<Paragraph
 						pilcrow={{
-							move: {
+							moveTo: {
 								id: 53,
-								type: 'to',
 								author: author,
 								date: date,
 							},
 						}}
 					>
-						<Move id={54} type="to" author={author} date={date}>
+						<MoveTo id={54} author={author} date={date}>
 							<Text>
 								Critique of social and familial repression,
 								especially against women
 							</Text>
-						</Move>
+						</MoveTo>
 					</Paragraph>
 				</Cell>
 			</Row>
@@ -144,9 +139,8 @@ await Docx.fromJsx(
 				<Cell>
 					<Paragraph
 						pilcrow={{
-							move: {
+							moveFrom: {
 								id: 12,
-								type: 'from',
 								author: author,
 								date: date,
 							},
@@ -158,25 +152,24 @@ await Docx.fromJsx(
 							author={author}
 							date={date}
 						/>
-						<Move id={14} type="from" author={author} date={date}>
+						<MoveFrom id={14} author={author} date={date}>
 							<Text> Author</Text>
-						</Move>
+						</MoveFrom>
 					</Paragraph>
 				</Cell>
 				<Cell>
 					<Paragraph
 						pilcrow={{
-							move: {
+							moveFrom: {
 								id: 35,
-								type: 'from',
 								author: author,
 								date: date,
 							},
 						}}
 					>
-						<Move id={36} type="from" author={author} date={date}>
+						<MoveFrom id={36} author={author} date={date}>
 							<Text>Federico García Lorca</Text>
-						</Move>
+						</MoveFrom>
 					</Paragraph>
 				</Cell>
 			</Row>
@@ -184,33 +177,31 @@ await Docx.fromJsx(
 				<Cell>
 					<Paragraph
 						pilcrow={{
-							move: {
+							moveFrom: {
 								id: 37,
-								type: 'from',
 								author: author,
 								date: date,
 							},
 						}}
 					>
-						<Move id={38} type="from" author={author} date={date}>
+						<MoveFrom id={38} author={author} date={date}>
 							<Text>Genre</Text>
-						</Move>
+						</MoveFrom>
 					</Paragraph>
 				</Cell>
 				<Cell>
 					<Paragraph
 						pilcrow={{
-							move: {
+							moveFrom: {
 								id: 39,
-								type: 'from',
 								author: author,
 								date: date,
 							},
 						}}
 					>
-						<Move id={40} type="from" author={author} date={date}>
+						<MoveFrom id={40} author={author} date={date}>
 							<Text>Tragedy</Text>
-						</Move>
+						</MoveFrom>
 					</Paragraph>
 				</Cell>
 			</Row>
@@ -218,36 +209,34 @@ await Docx.fromJsx(
 				<Cell>
 					<Paragraph
 						pilcrow={{
-							move: {
+							moveFrom: {
 								id: 41,
-								type: 'from',
 								author: author,
 								date: date,
 							},
 						}}
 					>
-						<Move id={42} type="from" author={author} date={date}>
+						<MoveFrom id={42} author={author} date={date}>
 							<Text>Message</Text>
-						</Move>
+						</MoveFrom>
 					</Paragraph>
 				</Cell>
 				<Cell>
 					<Paragraph
 						pilcrow={{
-							move: {
+							moveFrom: {
 								id: 43,
-								type: 'from',
 								author: author,
 								date: date,
 							},
 						}}
 					>
-						<Move id={44} type="from" author={author} date={date}>
+						<MoveFrom id={44} author={author} date={date}>
 							<Text>
 								Critique of social and familial repression,
 								especially against women
 							</Text>
-						</Move>
+						</MoveFrom>
 					</Paragraph>
 				</Cell>
 			</Row>

--- a/examples/track-changes/track-changes-insertion.tsx
+++ b/examples/track-changes/track-changes-insertion.tsx
@@ -2,7 +2,6 @@
 import Docx, {
 	Cell,
 	cm,
-	Deletion,
 	Image,
 	Insertion,
 	Paragraph,
@@ -86,9 +85,9 @@ await Docx.fromJsx(
 				having a secret affair with Adela,
 			</Text>
 			{/* Text insertion */}
-			<Deletion id={3} author={author} date={date}>
+			<Insertion id={3} author={author} date={date}>
 				<Text> the youngest daughter.</Text>
-			</Deletion>
+			</Insertion>
 		</Paragraph>
 		<Paragraph>
 			{/* Text with inline styles insertion */}

--- a/examples/track-changes/track-changes-insertion.tsx
+++ b/examples/track-changes/track-changes-insertion.tsx
@@ -2,6 +2,7 @@
 import Docx, {
 	Cell,
 	cm,
+	Deletion,
 	Image,
 	Insertion,
 	Paragraph,
@@ -85,9 +86,9 @@ await Docx.fromJsx(
 				having a secret affair with Adela,
 			</Text>
 			{/* Text insertion */}
-			<Insertion id={3} author={author} date={date}>
+			<Deletion id={3} author={author} date={date}>
 				<Text> the youngest daughter.</Text>
-			</Insertion>
+			</Deletion>
 		</Paragraph>
 		<Paragraph>
 			{/* Text with inline styles insertion */}

--- a/lib/components/document/src/Paragraph.ts
+++ b/lib/components/document/src/Paragraph.ts
@@ -36,11 +36,12 @@ import type { CommentRangeStart } from '../../comments/src/CommentRangeStart.ts'
 import type { Text } from '../../document/src/Text.ts';
 import type { Deletion } from '../../track-changes/src/Deletion.ts';
 import type { Insertion } from '../../track-changes/src/Insertion.ts';
-import type { Move } from '../../track-changes/src/Move.ts';
+import type { MoveFrom } from '../../track-changes/src/MoveFrom.ts';
 import type { MoveFromRangeEnd } from '../../track-changes/src/MoveFromRangeEnd.ts';
 import type { MoveFromRangeStart } from '../../track-changes/src/MoveFromRangeStart.ts';
 import type { MoveToRangeEnd } from '../../track-changes/src/MoveToRangeEnd.ts';
 import type { MoveToRangeStart } from '../../track-changes/src/MoveToRangeStart.ts';
+import type { MoveTo } from '../../track-changes/src/MoveTo.ts';
 import type { BookmarkRangeEnd } from './BookmarkRangeEnd.ts';
 import type { BookmarkRangeStart } from './BookmarkRangeStart.ts';
 import type { Field } from './Field.ts';
@@ -61,7 +62,8 @@ export type ParagraphChild =
 	| Hyperlink
 	| Field
 	| FootnoteReference
-	| Move
+	| MoveTo
+	| MoveFrom
 	| MoveToRangeStart
 	| MoveToRangeEnd
 	| MoveFromRangeStart
@@ -96,7 +98,8 @@ export class Paragraph extends Component<ParagraphProps, ParagraphChild> {
 		'Field',
 		'FootnoteReference',
 		'FootnoteAnchor',
-		'Move',
+		'MoveTo',
+		'MoveFrom',
 		'MoveToRangeStart',
 		'MoveToRangeEnd',
 		'MoveFromRangeStart',

--- a/lib/components/document/src/Section.ts
+++ b/lib/components/document/src/Section.ts
@@ -22,7 +22,8 @@ import {
 } from '../../../utilities/src/components.ts';
 import { QNS } from '../../../utilities/src/namespaces.ts';
 import { evaluateXPathToMap } from '../../../utilities/src/xquery.ts';
-import type { Move } from '../../track-changes/src/Move.ts';
+import type { MoveFrom } from '../../track-changes/src/MoveFrom.ts';
+import type { MoveTo } from '../../track-changes/src/MoveTo.ts';
 import type { BookmarkRangeEnd } from './BookmarkRangeEnd.ts';
 import type { BookmarkRangeStart } from './BookmarkRangeStart.ts';
 import { Paragraph } from './Paragraph.ts';
@@ -36,14 +37,16 @@ export type SectionChild =
 	| Table
 	| BookmarkRangeStart
 	| BookmarkRangeEnd
-	| Move;
+	| MoveTo
+	| MoveFrom;
 
 export const sectionChildComponentNames = [
 	'Table',
 	'Paragraph',
 	'BookmarkRangeStart',
 	'BookmarkRangeEnd',
-	'Move',
+	'MoveTo',
+	'MoveFrom',
 ];
 
 /**

--- a/lib/components/document/src/Text.ts
+++ b/lib/components/document/src/Text.ts
@@ -147,7 +147,9 @@ export class Text extends Component<TextProps, TextChild> {
 							${QNS.w}drawing,
 							${QNS.w}t/text(),
 							${QNS.w}fldChar,
-							${QNS.w}instrText
+							${QNS.w}instrText,
+							${QNS.w}moveTo, 
+							${QNS.w}moveFrom
 						)
 					}
 				}

--- a/lib/components/track-changes/src/Deletion.ts
+++ b/lib/components/track-changes/src/Deletion.ts
@@ -21,9 +21,10 @@ import type { BookmarkRangeStart } from '../../document/src/BookmarkRangeStart.t
 import type { FootnoteReference } from '../../document/src/FootnoteReference.ts';
 import type { DeletedText } from "./DeletedText.ts";
 import type { Insertion } from './Insertion.ts';
-import type { Move } from './Move.ts';
+import type { MoveFrom } from './MoveFrom.ts';
 import type { MoveFromRangeEnd } from './MoveFromRangeEnd.ts';
 import type { MoveFromRangeStart } from './MoveFromRangeStart.ts';
+import type { MoveTo } from './MoveTo.ts';
 import type { MoveToRangeEnd } from './MoveToRangeEnd.ts';
 import type { MoveToRangeStart } from './MoveToRangeStart.ts';
 /**
@@ -35,7 +36,8 @@ export type DeletionChild =
 	| CommentRangeStart
 	| CommentRangeEnd
 	| DeletedText
-	| Move
+	| MoveTo
+	| MoveFrom
 	| MoveToRangeStart
 	| MoveToRangeEnd
 	| MoveFromRangeStart
@@ -65,7 +67,8 @@ export class Deletion extends Component<DeletionProps, DeletionChild> {
 		'CommentRangeStart',
 		'CommentRangeEnd',
 		'DeletedText',
-		'Move',
+		'MoveFrom',
+		'MoveTo',
 		'MoveToRangeStart',
 		'MoveToRangeEnd',
 		'MoveFromRangeStart',

--- a/lib/components/track-changes/src/Insertion.ts
+++ b/lib/components/track-changes/src/Insertion.ts
@@ -21,11 +21,12 @@ import type { BookmarkRangeStart } from '../../document/src/BookmarkRangeStart.t
 import type { FootnoteReference } from '../../document/src/FootnoteReference.ts';
 import type { Text } from '../../document/src/Text.ts';
 import type { Deletion } from './Deletion.ts';
-import type { Move } from './Move.ts';
+import type { MoveFrom } from './MoveFrom.ts';
 import type { MoveFromRangeEnd } from './MoveFromRangeEnd.ts';
 import type { MoveFromRangeStart } from './MoveFromRangeStart.ts';
 import type { MoveToRangeEnd } from './MoveToRangeEnd.ts';
 import type { MoveToRangeStart } from './MoveToRangeStart.ts';
+import type { MoveTo } from './MoveTo.ts';
 
 /**
  * A type specifying the children of {@link Insertion}.
@@ -36,7 +37,8 @@ export type InsertionChild =
 	| CommentRangeStart
 	| CommentRangeEnd
 	| Text
-	| Move
+	| MoveTo
+	| MoveFrom
 	| Insertion
 	| MoveToRangeStart
 	| MoveToRangeEnd
@@ -67,7 +69,8 @@ export class Insertion extends Component<InsertionProps, InsertionChild> {
 		'CommentRangeStart',
 		'CommentRangeEnd',
 		'Text',
-		'Move',
+		'MoveTo',
+		'MoveFrom',
 		'MoveToRangeStart',
 		'MoveToRangeEnd',
 		'MoveFromRangeStart',

--- a/lib/components/track-changes/src/MoveFrom.ts
+++ b/lib/components/track-changes/src/MoveFrom.ts
@@ -1,9 +1,10 @@
 // Import without assignment ensures Deno does not tree-shake this component. To avoid circular
 // definitions, components register themselves in a side-effect of their module.
 
-import type {
-	ComponentAncestor,
-	ComponentContext,
+import {
+	Component,
+	type ComponentAncestor,
+	type ComponentContext,
 } from '../../../classes/src/Component.ts';
 import type { ChangeInformation } from '../../../utilities/src/changes.ts';
 import {
@@ -14,7 +15,6 @@ import { create } from '../../../utilities/src/dom.ts';
 import { QNS } from '../../../utilities/src/namespaces.ts';
 import { evaluateXPathToMap } from '../../../utilities/src/xquery.ts';
 import type { MoveToChild } from './MoveTo.ts';
-import { MoveTo } from './MoveTo.ts';
 
 /**
  * A type specifying the children of {@link MoveFrom}.
@@ -26,32 +26,47 @@ export type MoveFromChild = MoveToChild;
 export type MoveFromProps = ChangeInformation;
 
 /**
- * A component that represents a change-tracked text or paragraph that was moved.
+ * A component that represents a change-tracked text or paragraph that was moved from one location to another.
  *
- * If a `Move` is present outside the text-properties, then paragraphs appear as a insertion in Word.
+ * If a `MoveFrom` is present outside the text-properties, then paragraphs appear as a deletion in Word.
  *
  * Additional documentation is here:
  * 	- https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_moveTo_topic_ID0EE3IW.html#topic_ID0EE3IW
  * 	- https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_moveTo_topic_ID0EXMJW.html
  */
-export class MoveFrom extends MoveTo {
+export class MoveFrom extends Component<MoveFromProps, MoveFromChild> {
+	public static override readonly children: string[] = [
+		'BookmarkRangeEnd',
+		'BookmarkRangeStart',
+		'CommentRangeStart',
+		'CommentRangeEnd',
+		'Text',
+		'MoveToRangeStart',
+		'MoveToRangeEnd',
+		'MoveFromRangeStart',
+		'MoveFromRangeEnd',
+		'MoveTo',
+		'MoveFrom',
+		'Insertion',
+		'Deletion',
+		'FootnoteReference',
+		this.name,
+	];
+
+	public static override readonly mixed: boolean = false;
+
 	/**
 	 * Creates an XML DOM node for this component instance.
 	 */
 	public override async toNode(ancestry: ComponentAncestor[]): Promise<Node> {
 		return create(
 			`
-				let $attrs := [
+				element ${QNS.w}moveFrom { 
 					attribute ${QNS.w}id { $id }, 
 					if ($date) then attribute ${QNS.w}date { $date } else (),
-					if ($author) then attribute ${QNS.w}author { $author } else ()
-				]
-				return (
-					element ${QNS.w}moveFrom { 
-						$attrs,
-						$children
-					}
-				)
+					if ($author) then attribute ${QNS.w}author { $author } else (), 
+					$children
+				}
 			`,
 			{
 				...this.props,

--- a/lib/components/track-changes/src/MoveFrom.ts
+++ b/lib/components/track-changes/src/MoveFrom.ts
@@ -13,35 +13,13 @@ import {
 import { create } from '../../../utilities/src/dom.ts';
 import { QNS } from '../../../utilities/src/namespaces.ts';
 import { evaluateXPathToMap } from '../../../utilities/src/xquery.ts';
-import type { CommentRangeEnd } from '../../comments/src/CommentRangeEnd.ts';
-import type { CommentRangeStart } from '../../comments/src/CommentRangeStart.ts';
-import type { BookmarkRangeEnd } from '../../document/src/BookmarkRangeEnd.ts';
-import type { BookmarkRangeStart } from '../../document/src/BookmarkRangeStart.ts';
-import type { FootnoteReference } from '../../document/src/FootnoteReference.ts';
-import type { Text } from '../../document/src/Text.ts';
-import type { Deletion } from './Deletion.ts';
-import type { Insertion } from './Insertion.ts';
-import type { MoveRangeEnd } from './MoveRangeEnd.ts';
-import type { MoveRangeStart } from './MoveRangeStart.ts';
+import type { MoveToChild } from './MoveTo.ts';
 import { MoveTo } from './MoveTo.ts';
 
 /**
- * A type specifying the children of {@link Move}.
+ * A type specifying the children of {@link MoveFrom}.
  */
-export type MoveFromChild =
-	| BookmarkRangeStart
-	| BookmarkRangeEnd
-	| CommentRangeStart
-	| CommentRangeEnd
-	| Text
-	| MoveFrom
-	| MoveTo
-	| MoveRangeStart
-	| MoveRangeEnd
-	| Insertion
-	| Deletion
-	| FootnoteReference;
-
+export type MoveFromChild = MoveToChild;
 /**
  * A type describing the props accepted by {@link MoveFrom}.
  */

--- a/lib/components/track-changes/src/MoveFrom.ts
+++ b/lib/components/track-changes/src/MoveFrom.ts
@@ -1,10 +1,9 @@
 // Import without assignment ensures Deno does not tree-shake this component. To avoid circular
 // definitions, components register themselves in a side-effect of their module.
 
-import {
-	Component,
-	type ComponentAncestor,
-	type ComponentContext,
+import type {
+	ComponentAncestor,
+	ComponentContext,
 } from '../../../classes/src/Component.ts';
 import type { ChangeInformation } from '../../../utilities/src/changes.ts';
 import {
@@ -24,7 +23,7 @@ import type { Deletion } from './Deletion.ts';
 import type { Insertion } from './Insertion.ts';
 import type { MoveRangeEnd } from './MoveRangeEnd.ts';
 import type { MoveRangeStart } from './MoveRangeStart.ts';
-import type { MoveTo } from './MoveTo.ts';
+import { MoveTo } from './MoveTo.ts';
 
 /**
  * A type specifying the children of {@link Move}.
@@ -44,14 +43,9 @@ export type MoveFromChild =
 	| FootnoteReference;
 
 /**
- * Create a unique property so that TypeScript's structural typing does not allow us to use
- * components with otherwise identical allowable properties and children interchangeably.
- */
-const __brand: symbol = Symbol();
-/**
  * A type describing the props accepted by {@link MoveFrom}.
  */
-export type MoveFromProps = ChangeInformation & { [__brand]: never };
+export type MoveFromProps = ChangeInformation;
 
 /**
  * A component that represents a change-tracked text or paragraph that was moved.
@@ -62,25 +56,7 @@ export type MoveFromProps = ChangeInformation & { [__brand]: never };
  * 	- https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_moveTo_topic_ID0EE3IW.html#topic_ID0EE3IW
  * 	- https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_moveTo_topic_ID0EXMJW.html
  */
-export class MoveFrom extends Component<MoveFromProps, MoveFromChild> {
-	public static override readonly children: string[] = [
-		'BookmarkRangeEnd',
-		'BookmarkRangeStart',
-		'CommentRangeStart',
-		'CommentRangeEnd',
-		'Text',
-		'MoveTo',
-		'MoveFrom',
-		'MoveRangeStart',
-		'MoveRangeEnd',
-		'Insertion',
-		'Deletion',
-		'FootnoteReference',
-		this.name,
-	];
-
-	public static override readonly mixed: boolean = false;
-
+export class MoveFrom extends MoveTo {
 	/**
 	 * Creates an XML DOM node for this component instance.
 	 */

--- a/lib/components/track-changes/src/MoveFrom.ts
+++ b/lib/components/track-changes/src/MoveFrom.ts
@@ -22,33 +22,36 @@ import type { FootnoteReference } from '../../document/src/FootnoteReference.ts'
 import type { Text } from '../../document/src/Text.ts';
 import type { Deletion } from './Deletion.ts';
 import type { Insertion } from './Insertion.ts';
-import type { MoveFromRangeEnd } from './MoveFromRangeEnd.ts';
-import type { MoveFromRangeStart } from './MoveFromRangeStart.ts';
-import type { MoveToRangeEnd } from './MoveToRangeEnd.ts';
-import type { MoveToRangeStart } from './MoveToRangeStart.ts';
+import type { MoveRangeEnd } from './MoveRangeEnd.ts';
+import type { MoveRangeStart } from './MoveRangeStart.ts';
+import type { MoveTo } from './MoveTo.ts';
 
 /**
  * A type specifying the children of {@link Move}.
  */
-export type MoveChild =
+export type MoveFromChild =
 	| BookmarkRangeStart
 	| BookmarkRangeEnd
 	| CommentRangeStart
 	| CommentRangeEnd
 	| Text
-	| Move
-	| MoveToRangeStart
-	| MoveToRangeEnd
-	| MoveFromRangeStart
-	| MoveFromRangeEnd
+	| MoveFrom
+	| MoveTo
+	| MoveRangeStart
+	| MoveRangeEnd
 	| Insertion
 	| Deletion
 	| FootnoteReference;
 
 /**
- * A type describing the props accepted by {@link Move}.
+ * Create a unique property so that TypeScript's structural typing does not allow us to use
+ * components with otherwise identical allowable properties and children interchangeably.
  */
-export type MoveProps = ChangeInformation & { type: 'to' | 'from' };
+const __brand: symbol = Symbol();
+/**
+ * A type describing the props accepted by {@link MoveFrom}.
+ */
+export type MoveFromProps = ChangeInformation & { [__brand]: never };
 
 /**
  * A component that represents a change-tracked text or paragraph that was moved.
@@ -59,17 +62,17 @@ export type MoveProps = ChangeInformation & { type: 'to' | 'from' };
  * 	- https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_moveTo_topic_ID0EE3IW.html#topic_ID0EE3IW
  * 	- https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_moveTo_topic_ID0EXMJW.html
  */
-export class Move extends Component<MoveProps, MoveChild> {
+export class MoveFrom extends Component<MoveFromProps, MoveFromChild> {
 	public static override readonly children: string[] = [
 		'BookmarkRangeEnd',
 		'BookmarkRangeStart',
 		'CommentRangeStart',
 		'CommentRangeEnd',
 		'Text',
-		'MoveToRangeStart',
-		'MoveToRangeEnd',
-		'MoveFromRangeStart',
-		'MoveFromRangeEnd',
+		'MoveTo',
+		'MoveFrom',
+		'MoveRangeStart',
+		'MoveRangeEnd',
 		'Insertion',
 		'Deletion',
 		'FootnoteReference',
@@ -89,12 +92,11 @@ export class Move extends Component<MoveProps, MoveChild> {
 					if ($date) then attribute ${QNS.w}date { $date } else (),
 					if ($author) then attribute ${QNS.w}author { $author } else ()
 				]
-				let $moveType := 
-					switch ($type)
-					case 'to' return element ${QNS.w}moveTo { $attrs, $children } 
-					case 'from' return element ${QNS.w}moveFrom { $attrs, $children } 
-					default return () 
-				return $moveType
+				return (
+					element ${QNS.w}moveFrom { 
+						$attrs
+					}
+				)
 			`,
 			{
 				...this.props,
@@ -109,16 +111,16 @@ export class Move extends Component<MoveProps, MoveChild> {
 	 * Asserts whether or not a given XML node correlates with this component.
 	 */
 	static override matchesNode(node: Node): boolean {
-		return node.nodeName === 'w:moveFrom' || node.nodeName === 'w:moveTo';
+		return node.nodeName === 'w:moveFrom';
 	}
 
 	/**
 	 * Instantiate this component from the XML in an existing DOCX file.
 	 */
-	static override fromNode(node: Node, context: ComponentContext): Move {
+	static override fromNode(node: Node, context: ComponentContext): MoveFrom {
 		const { children, changeProps } = evaluateXPathToMap<{
 			children: Node[];
-			changeProps: MoveProps;
+			changeProps: MoveFromProps;
 		}>(
 			`
 			map { 
@@ -139,7 +141,6 @@ export class Move extends Component<MoveProps, MoveChild> {
 				)}, 
 				"changeProps": map { 
 					"id": @${QNS.w}id/number(),
-					"type": if ($nodeName eq 'moveTo') then 'to' else 'from',
 					"date": if (@${QNS.w}date) then @${QNS.w}date/string() else (),
 					"author": if (@${QNS.w}author) then @${QNS.w}author/string() else ()
 				}
@@ -149,13 +150,13 @@ export class Move extends Component<MoveProps, MoveChild> {
 			null,
 			{ nodeName: (node as Element).localName }
 		);
-		return new Move(
+		return new MoveFrom(
 			{
 				...changeProps,
 				date: changeProps.date ? new Date(changeProps.date) : undefined,
 				author: changeProps.author ? changeProps.author : undefined,
 			},
-			...createChildComponentsFromNodes<MoveChild>(
+			...createChildComponentsFromNodes<MoveFromChild>(
 				this.children,
 				children,
 				context
@@ -164,4 +165,4 @@ export class Move extends Component<MoveProps, MoveChild> {
 	}
 }
 
-registerComponent(Move);
+registerComponent(MoveFrom);

--- a/lib/components/track-changes/src/MoveFrom.ts
+++ b/lib/components/track-changes/src/MoveFrom.ts
@@ -70,7 +70,8 @@ export class MoveFrom extends MoveTo {
 				]
 				return (
 					element ${QNS.w}moveFrom { 
-						$attrs
+						$attrs,
+						$children
 					}
 				)
 			`,

--- a/lib/components/track-changes/src/MoveTo.ts
+++ b/lib/components/track-changes/src/MoveTo.ts
@@ -44,15 +44,9 @@ export type MoveToChild =
 	| FootnoteReference;
 
 /**
- * Create a unique property so that TypeScript's structural typing does not allow us to use
- * components with otherwise identical allowable properties and children interchangeably.
- */
-const __brand: symbol = Symbol();
-
-/**
  * A type describing the props accepted by {@link Move}.
  */
-export type MoveToProps = ChangeInformation & { [__brand]: never };
+export type MoveToProps = ChangeInformation;
 
 /**
  * A component that represents a change-tracked text or paragraph that was moved.

--- a/lib/components/track-changes/src/MoveTo.ts
+++ b/lib/components/track-changes/src/MoveTo.ts
@@ -82,22 +82,18 @@ export class MoveTo extends Component<MoveToProps, MoveToChild> {
 	public override async toNode(ancestry: ComponentAncestor[]): Promise<Node> {
 		return create(
 			`
-				let $attrs := [
+				element ${QNS.w}moveTo { 
 					attribute ${QNS.w}id { $id }, 
-					if ($date) then attribute ${QNS.w}date { $date } else (),
-					if ($author) then attribute ${QNS.w}author { $author } else ()
-				]
-				return ( 
-					element ${QNS.w}moveTo { 
-						$attrs,
-						$children
-					}
-				)
+					if (exists($date)) then attribute ${QNS.w}date { $date } else (),
+					if (exists($author)) then attribute ${QNS.w}author { $author } else (),
+					$children
+				}
+
 			`,
 			{
 				...this.props,
-				// author: this.props.author ? this.props.author : null,
 				date: this.props.date ? this.props.date.toISOString() : null,
+				author: this.props.author ? this.props.author : null,
 				children: await this.childrenToNode(ancestry),
 			}
 		);
@@ -149,8 +145,8 @@ export class MoveTo extends Component<MoveToProps, MoveToChild> {
 		return new MoveTo(
 			{
 				...changeProps,
+				author: changeProps.author ? changeProps.author : undefined,
 				date: changeProps.date ? new Date(changeProps.date) : undefined,
-				// author: changeProps.author ? changeProps.author : undefined,
 			},
 			...createChildComponentsFromNodes<MoveToChild>(
 				this.children,

--- a/lib/components/track-changes/src/MoveTo.ts
+++ b/lib/components/track-changes/src/MoveTo.ts
@@ -23,8 +23,10 @@ import type { Text } from '../../document/src/Text.ts';
 import type { Deletion } from './Deletion.ts';
 import type { Insertion } from './Insertion.ts';
 import type { MoveFrom } from './MoveFrom.ts';
-import type { MoveRangeEnd } from './MoveRangeEnd.ts';
-import type { MoveRangeStart } from './MoveRangeStart.ts';
+import type { MoveFromRangeEnd } from './MoveFromRangeEnd.ts';
+import type { MoveFromRangeStart } from './MoveFromRangeStart.ts';
+import type { MoveToRangeEnd } from './MoveToRangeEnd.ts';
+import type { MoveToRangeStart } from './MoveToRangeStart.ts';
 
 /**
  * A type specifying the children of {@link MoveTo}.
@@ -37,8 +39,10 @@ export type MoveToChild =
 	| Text
 	| MoveTo
 	| MoveFrom
-	| MoveRangeStart
-	| MoveRangeEnd
+	| MoveToRangeStart
+	| MoveToRangeEnd
+	| MoveFromRangeStart
+	| MoveFromRangeEnd
 	| Insertion
 	| Deletion
 	| FootnoteReference;
@@ -64,8 +68,10 @@ export class MoveTo extends Component<MoveToProps, MoveToChild> {
 		'CommentRangeStart',
 		'CommentRangeEnd',
 		'Text',
-		'MoveRangeStart',
-		'MoveRangeEnd',
+		'MoveToRangeStart',
+		'MoveToRangeEnd',
+		'MoveFromRangeStart',
+		'MoveFromRangeEnd',
 		'MoveTo',
 		'MoveFrom',
 		'Insertion',

--- a/lib/components/track-changes/src/MoveTo.ts
+++ b/lib/components/track-changes/src/MoveTo.ts
@@ -96,8 +96,8 @@ export class MoveTo extends Component<MoveToProps, MoveToChild> {
 			`,
 			{
 				...this.props,
+				// author: this.props.author ? this.props.author : null,
 				date: this.props.date ? this.props.date.toISOString() : null,
-				author: this.props.author ? this.props.author : null,
 				children: await this.childrenToNode(ancestry),
 			}
 		);
@@ -150,7 +150,7 @@ export class MoveTo extends Component<MoveToProps, MoveToChild> {
 			{
 				...changeProps,
 				date: changeProps.date ? new Date(changeProps.date) : undefined,
-				author: changeProps.author ? changeProps.author : undefined,
+				// author: changeProps.author ? changeProps.author : undefined,
 			},
 			...createChildComponentsFromNodes<MoveToChild>(
 				this.children,

--- a/lib/components/track-changes/src/MoveTo.ts
+++ b/lib/components/track-changes/src/MoveTo.ts
@@ -27,7 +27,7 @@ import type { MoveRangeEnd } from './MoveRangeEnd.ts';
 import type { MoveRangeStart } from './MoveRangeStart.ts';
 
 /**
- * A type specifying the children of {@link Move}.
+ * A type specifying the children of {@link MoveTo}.
  */
 export type MoveToChild =
 	| BookmarkRangeStart
@@ -44,7 +44,7 @@ export type MoveToChild =
 	| FootnoteReference;
 
 /**
- * A type describing the props accepted by {@link Move}.
+ * A type describing the props accepted by {@link MoveTo}.
  */
 export type MoveToProps = ChangeInformation;
 

--- a/lib/components/track-changes/src/MoveTo.ts
+++ b/lib/components/track-changes/src/MoveTo.ts
@@ -1,0 +1,170 @@
+// Import without assignment ensures Deno does not tree-shake this component. To avoid circular
+// definitions, components register themselves in a side-effect of their module.
+
+import {
+	Component,
+	type ComponentAncestor,
+	type ComponentContext,
+} from '../../../classes/src/Component.ts';
+import type { ChangeInformation } from '../../../utilities/src/changes.ts';
+import {
+	createChildComponentsFromNodes,
+	registerComponent,
+} from '../../../utilities/src/components.ts';
+import { create } from '../../../utilities/src/dom.ts';
+import { QNS } from '../../../utilities/src/namespaces.ts';
+import { evaluateXPathToMap } from '../../../utilities/src/xquery.ts';
+import type { CommentRangeEnd } from '../../comments/src/CommentRangeEnd.ts';
+import type { CommentRangeStart } from '../../comments/src/CommentRangeStart.ts';
+import type { BookmarkRangeEnd } from '../../document/src/BookmarkRangeEnd.ts';
+import type { BookmarkRangeStart } from '../../document/src/BookmarkRangeStart.ts';
+import type { FootnoteReference } from '../../document/src/FootnoteReference.ts';
+import type { Text } from '../../document/src/Text.ts';
+import type { Deletion } from './Deletion.ts';
+import type { Insertion } from './Insertion.ts';
+import type { MoveFrom } from './MoveFrom.ts';
+import type { MoveRangeEnd } from './MoveRangeEnd.ts';
+import type { MoveRangeStart } from './MoveRangeStart.ts';
+
+/**
+ * A type specifying the children of {@link Move}.
+ */
+export type MoveToChild =
+	| BookmarkRangeStart
+	| BookmarkRangeEnd
+	| CommentRangeStart
+	| CommentRangeEnd
+	| Text
+	| MoveTo
+	| MoveFrom
+	| MoveRangeStart
+	| MoveRangeEnd
+	| Insertion
+	| Deletion
+	| FootnoteReference;
+
+/**
+ * Create a unique property so that TypeScript's structural typing does not allow us to use
+ * components with otherwise identical allowable properties and children interchangeably.
+ */
+const __brand: symbol = Symbol();
+
+/**
+ * A type describing the props accepted by {@link Move}.
+ */
+export type MoveToProps = ChangeInformation & { [__brand]: never };
+
+/**
+ * A component that represents a change-tracked text or paragraph that was moved.
+ *
+ * If a `Move` is present outside the text-properties, then paragraphs appear as a insertion in Word.
+ *
+ * Additional documentation is here:
+ * 	- https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_moveTo_topic_ID0EE3IW.html#topic_ID0EE3IW
+ * 	- https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_moveTo_topic_ID0EXMJW.html
+ */
+export class MoveTo extends Component<MoveToProps, MoveToChild> {
+	public static override readonly children: string[] = [
+		'BookmarkRangeEnd',
+		'BookmarkRangeStart',
+		'CommentRangeStart',
+		'CommentRangeEnd',
+		'Text',
+		'MoveRangeStart',
+		'MoveRangeEnd',
+		'MoveTo',
+		'MoveFrom',
+		'Insertion',
+		'Deletion',
+		'FootnoteReference',
+		this.name,
+	];
+
+	public static override readonly mixed: boolean = false;
+
+	/**
+	 * Creates an XML DOM node for this component instance.
+	 */
+	public override async toNode(ancestry: ComponentAncestor[]): Promise<Node> {
+		return create(
+			`
+				let $attrs := [
+					attribute ${QNS.w}id { $id }, 
+					if ($date) then attribute ${QNS.w}date { $date } else (),
+					if ($author) then attribute ${QNS.w}author { $author } else ()
+				]
+				return ( 
+					element ${QNS.w}moveTo { 
+						$attrs,
+						$children
+					}
+				)
+			`,
+			{
+				...this.props,
+				date: this.props.date ? this.props.date.toISOString() : null,
+				author: this.props.author ? this.props.author : null,
+				children: await this.childrenToNode(ancestry),
+			}
+		);
+	}
+
+	/**
+	 * Asserts whether or not a given XML node correlates with this component.
+	 */
+	static override matchesNode(node: Node): boolean {
+		return node.nodeName === 'w:moveTo';
+	}
+
+	/**
+	 * Instantiate this component from the XML in an existing DOCX file.
+	 */
+	static override fromNode(node: Node, context: ComponentContext): MoveTo {
+		const { children, changeProps } = evaluateXPathToMap<{
+			children: Node[];
+			changeProps: MoveToProps;
+		}>(
+			`
+			map { 
+				"children": array{./(
+					${QNS.w}r |
+					${QNS.w}ins |
+					${QNS.w}del |
+					${QNS.w}commentRangeStart |
+					${QNS.w}commentRangeEnd |
+					${QNS.w}bookmarkStart |
+					${QNS.w}bookmarkEnd | 
+					${QNS.w}moveTo | 
+					${QNS.w}moveFrom | 
+					${QNS.w}moveToRangeStart | 
+					${QNS.w}moveToRangeEnd | 
+					${QNS.w}moveFromRangeStart | 
+					${QNS.w}moveFromRangeEnd
+				)}, 
+				"changeProps": map { 
+					"id": @${QNS.w}id/number(),
+					"date": if (@${QNS.w}date) then @${QNS.w}date/string() else (),
+					"author": if (@${QNS.w}author) then @${QNS.w}author/string() else ()
+				}
+
+			}`,
+			node,
+			null,
+			{ nodeName: (node as Element).localName }
+		);
+		return new MoveTo(
+			{
+				...changeProps,
+				date: changeProps.date ? new Date(changeProps.date) : undefined,
+				author: changeProps.author ? changeProps.author : undefined,
+			},
+			...createChildComponentsFromNodes<MoveToChild>(
+				this.children,
+				children,
+				context
+			)
+		);
+	}
+}
+
+registerComponent(MoveTo);

--- a/lib/components/track-changes/src/MoveTo.ts
+++ b/lib/components/track-changes/src/MoveTo.ts
@@ -53,9 +53,9 @@ export type MoveToChild =
 export type MoveToProps = ChangeInformation;
 
 /**
- * A component that represents a change-tracked text or paragraph that was moved.
+ * A component that represents a change-tracked text or paragraph that was moved to a new location.
  *
- * If a `Move` is present outside the text-properties, then paragraphs appear as a insertion in Word.
+ * If a `MoveTo` is present outside the text-properties, then paragraphs appear as a insertion in Word.
  *
  * Additional documentation is here:
  * 	- https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_moveTo_topic_ID0EE3IW.html#topic_ID0EE3IW

--- a/lib/components/track-changes/test/Deletion.test.ts
+++ b/lib/components/track-changes/test/Deletion.test.ts
@@ -17,7 +17,8 @@ import { MoveFromRangeStart } from '../../track-changes/src/MoveFromRangeStart.t
 import { MoveToRangeEnd } from '../../track-changes/src/MoveToRangeEnd.ts';
 import { MoveToRangeStart } from '../../track-changes/src/MoveToRangeStart.ts';
 import { Deletion } from '../src/Deletion.ts';
-import { Move } from '../src/Move.ts';
+import { MoveFrom } from '../src/MoveFrom.ts';
+import { MoveTo } from '../src/MoveTo.ts';
 
 describe('Deletion', () => {
 	const date = new Date();
@@ -341,42 +342,38 @@ describe('Deletion', () => {
 
 			const deletedMove1 = new Deletion(
 				{ author: 'Luis', date: date, id: 1 },
-				new Move(
+				new MoveTo(
 					{
 						id: 0,
 						date: date,
 						author: 'Gabe',
-						type: 'to',
 					},
 					new Text({}, 'Moved content')
 				),
-				new Move(
+				new MoveFrom(
 					{
 						id: 0,
 						date: date,
 						author: 'Gabe',
-						type: 'from',
 					},
 					new Text({}, 'Moved content')
 				)
 			);
 			const deletedMove2 = new Deletion(
 				{ author: 'Roy', date: date, id: 2 },
-				new Move(
+				new MoveTo(
 					{
 						id: 1,
 						date: date,
 						author: 'Gabe',
-						type: 'to',
 					},
 					new Text({}, 'More moved content')
 				),
-				new Move(
+				new MoveFrom(
 					{
 						id: 1,
 						date: date,
 						author: 'Gabe',
-						type: 'from',
 					},
 					new Text({}, 'More moved content')
 				)

--- a/lib/components/track-changes/test/Insertion.test.ts
+++ b/lib/components/track-changes/test/Insertion.test.ts
@@ -6,7 +6,8 @@ import {
 	CommentRangeEnd,
 	CommentRangeStart,
 	Insertion,
-	Move,
+	MoveFrom,
+	MoveTo,
 	Paragraph,
 	Text,
 } from '../../../../mod.ts';
@@ -281,42 +282,38 @@ describe('Insertion', () => {
 
 			const insertedMove1 = new Insertion(
 				{ author: 'Luis', date: date, id: 1 },
-				new Move(
+				new MoveTo(
 					{
 						id: 0,
 						date: date,
 						author: 'Gabe',
-						type: 'to',
 					},
 					new Text({}, 'Moved content')
 				),
-				new Move(
+				new MoveFrom(
 					{
 						id: 0,
 						date: date,
 						author: 'Gabe',
-						type: 'from',
 					},
 					new Text({}, 'Moved content')
 				)
 			);
 			const insertedMove2 = new Insertion(
 				{ author: 'Roy', date: date, id: 2 },
-				new Move(
+				new MoveTo(
 					{
 						id: 1,
 						date: date,
 						author: 'Gabe',
-						type: 'to',
 					},
 					new Text({}, 'More moved content')
 				),
-				new Move(
+				new MoveFrom(
 					{
 						id: 1,
 						date: date,
 						author: 'Gabe',
-						type: 'from',
 					},
 					new Text({}, 'More moved content')
 				)

--- a/lib/components/track-changes/test/Move.test.ts
+++ b/lib/components/track-changes/test/Move.test.ts
@@ -1,14 +1,14 @@
 import { expect } from 'std/expect';
 import { describe, it } from 'std/testing/bdd';
 
-import { Paragraph } from '../../document/src/Paragraph.ts';
-import { Text } from '../../document/src/Text.ts';
-import { Move } from '../src/Move.ts';
-
 import { Archive } from '../../../classes/src/Archive.ts';
 import type { ComponentContext } from '../../../classes/src/Component.ts';
 import { create, serialize } from '../../../utilities/src/dom.ts';
 import { NamespaceUri } from '../../../utilities/src/namespaces.ts';
+import { Paragraph } from '../../document/src/Paragraph.ts';
+import { Text } from '../../document/src/Text.ts';
+import { MoveFrom } from '../src/MoveFrom.ts';
+import { MoveTo } from '../src/MoveTo.ts';
 
 describe('Move content in track changes...', () => {
 	const date = new Date();
@@ -160,12 +160,11 @@ describe('Move content in track changes...', () => {
 	// Testing a move inside a paragraph.
 	const moveToObject = new Paragraph(
 		{ style: null },
-		new Move(
+		new MoveTo(
 			{
 				id: 0,
 				date: date,
 				author: 'Gabe',
-				type: 'to',
 			},
 			new Text({}, 'This is a paragraph')
 		)
@@ -173,11 +172,10 @@ describe('Move content in track changes...', () => {
 
 	const moveToObjectWithoutDate = new Paragraph(
 		{ style: null },
-		new Move(
+		new MoveTo(
 			{
 				id: 0,
 				author: 'Gabe',
-				type: 'to',
 			},
 			new Text({}, 'This is a paragraph')
 		)
@@ -185,40 +183,36 @@ describe('Move content in track changes...', () => {
 
 	const moveToObjectWithoutAuthor = new Paragraph(
 		{ style: null },
-		new Move(
+		new MoveTo(
 			{
 				id: 0,
 				date: date,
-				type: 'to',
 			},
 			new Text({}, 'This is a paragraph')
 		)
 	);
 
 	// Testing a move as a stand-alone object
-	const moveFromObject = new Move(
+	const moveFromObject = new MoveFrom(
 		{
 			id: 1,
 			date: date,
 			author: 'Angel',
-			type: 'from',
 		},
 		new Text({}, 'This is a moveFrom node.')
 	);
 
-	const moveFromObjectWithoutAuthor = new Move(
+	const moveFromObjectWithoutAuthor = new MoveFrom(
 		{
 			id: 1,
 			date: date,
-			type: 'from',
 		},
 		new Text({}, 'This is a moveFrom node.')
 	);
-	const moveFromObjectWithoutDate = new Move(
+	const moveFromObjectWithoutDate = new MoveFrom(
 		{
 			id: 1,
 			author: 'Angel',
-			type: 'from',
 		},
 		new Text({}, 'This is a moveFrom node.')
 	);
@@ -226,10 +220,9 @@ describe('Move content in track changes...', () => {
 	const moveToAsPropObject = new Paragraph(
 		{
 			pilcrow: {
-				move: {
+				moveTo: {
 					author: 'Luis',
 					date: date,
-					type: 'to',
 					id: 1,
 				},
 			},
@@ -240,9 +233,8 @@ describe('Move content in track changes...', () => {
 	const moveToAsPropObjectWithoutAuthor = new Paragraph(
 		{
 			pilcrow: {
-				move: {
+				moveTo: {
 					date: date,
-					type: 'to',
 					id: 1,
 				},
 			},
@@ -253,9 +245,8 @@ describe('Move content in track changes...', () => {
 	const moveToAsPropObjectWithoutDate = new Paragraph(
 		{
 			pilcrow: {
-				move: {
+				moveTo: {
 					author: 'Luis',
-					type: 'to',
 					id: 1,
 				},
 			},
@@ -266,11 +257,10 @@ describe('Move content in track changes...', () => {
 	const moveFromAsPropObject = new Paragraph(
 		{
 			pilcrow: {
-				move: {
+				moveFrom: {
 					id: 2,
 					author: 'Ines',
 					date: date,
-					type: 'from',
 				},
 			},
 		},
@@ -280,10 +270,9 @@ describe('Move content in track changes...', () => {
 	const moveFromAsPropObjectWithoutAuthor = new Paragraph(
 		{
 			pilcrow: {
-				move: {
+				moveFrom: {
 					id: 2,
 					date: date,
-					type: 'from',
 				},
 			},
 		},
@@ -293,10 +282,9 @@ describe('Move content in track changes...', () => {
 	const moveFromAsPropObjectWithoutDate = new Paragraph(
 		{
 			pilcrow: {
-				move: {
+				moveFrom: {
 					id: 2,
 					author: 'Ines',
-					type: 'from',
 				},
 			},
 		},
@@ -315,12 +303,12 @@ describe('Move content in track changes...', () => {
 	);
 
 	// MoveFrom as an object
-	const newMoveFrom = Move.fromNode(moveFromNode, emptyContext);
-	const newMoveFromWithoutAuthor = Move.fromNode(
+	const newMoveFrom = MoveFrom.fromNode(moveFromNode, emptyContext);
+	const newMoveFromWithoutAuthor = MoveFrom.fromNode(
 		moveFromNodeWithoutAuthor,
 		emptyContext
 	);
-	const newMoveFromWithoutDate = Move.fromNode(
+	const newMoveFromWithoutDate = MoveFrom.fromNode(
 		moveFromNodeWithoutDate,
 		emptyContext
 	);
@@ -359,24 +347,24 @@ describe('Move content in track changes...', () => {
 		expect(newMoveFromWithoutAuthor).toEqual(moveFromObjectWithoutAuthor);
 		expect(newMoveFromWithoutDate).toEqual(moveFromObjectWithoutDate);
 
-		expect(newMoveToAsProp.props.pilcrow?.move).toEqual(
-			moveToAsPropObject.props.pilcrow?.move
+		expect(newMoveToAsProp.props.pilcrow?.moveTo).toEqual(
+			moveToAsPropObject.props.pilcrow?.moveTo
 		);
-		expect(newMoveToAsPropWithoutAuthor.props.pilcrow?.move).toEqual(
-			moveToAsPropObjectWithoutAuthor.props.pilcrow?.move
+		expect(newMoveToAsPropWithoutAuthor.props.pilcrow?.moveTo).toEqual(
+			moveToAsPropObjectWithoutAuthor.props.pilcrow?.moveTo
 		);
-		expect(newMoveToAsPropWithoutDate.props.pilcrow?.move).toEqual(
-			moveToAsPropObjectWithoutDate.props.pilcrow?.move
+		expect(newMoveToAsPropWithoutDate.props.pilcrow?.moveTo).toEqual(
+			moveToAsPropObjectWithoutDate.props.pilcrow?.moveTo
 		);
 
-		expect(newMoveFromAsProp.props.pilcrow?.move).toEqual(
-			moveFromAsPropObject.props.pilcrow?.move
+		expect(newMoveFromAsProp.props.pilcrow?.moveFrom).toEqual(
+			moveFromAsPropObject.props.pilcrow?.moveFrom
 		);
-		expect(newMoveFromAsPropWithoutAuthor.props.pilcrow?.move).toEqual(
-			moveFromAsPropObjectWithoutAuthor.props.pilcrow?.move
+		expect(newMoveFromAsPropWithoutAuthor.props.pilcrow?.moveFrom).toEqual(
+			moveFromAsPropObjectWithoutAuthor.props.pilcrow?.moveFrom
 		);
-		expect(newMoveFromAsPropWithoutDate.props.pilcrow?.move).toEqual(
-			moveFromAsPropObjectWithoutDate.props.pilcrow?.move
+		expect(newMoveFromAsPropWithoutDate.props.pilcrow?.moveFrom).toEqual(
+			moveFromAsPropObjectWithoutDate.props.pilcrow?.moveFrom
 		);
 	});
 

--- a/lib/properties/src/text-properties.ts
+++ b/lib/properties/src/text-properties.ts
@@ -142,7 +142,9 @@ export type TextProperties = {
 	 *
 	 * If present, the containing paragraph element will appear as a track-change moved paragraph.
 	 *
-	 * Read more here:  https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_moveTo_topic_ID0EE3IW.html
+	 * Read more here:
+	 * https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_moveTo_topic_ID0EE3IW.html and
+	 * https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_moveFrom_topic_ID0EJ6EW.html
 	 **/
 	moveTo?: MoveToProps | null;
 	moveFrom?: MoveFromProps | null;
@@ -452,9 +454,6 @@ export async function textPropertiesToNode(
 			moveTo: data.moveTo
 				? await new MoveTo({
 						...data.moveTo,
-						author: data.moveTo.author
-							? data.moveTo.author
-							: undefined,
 						date: data.moveTo.date
 							? new Date(data.moveTo.date)
 							: undefined,

--- a/lib/properties/src/text-properties.ts
+++ b/lib/properties/src/text-properties.ts
@@ -1,8 +1,12 @@
-import { Deletion, Insertion, type InsertionProps } from '../../../mod.ts';
 import {
-	Move,
-	type MoveProps,
-} from '../../components/track-changes/src/Move.ts';
+	Deletion,
+	Insertion,
+	MoveFrom,
+	MoveTo,
+	type InsertionProps,
+} from '../../../mod.ts';
+import type { MoveFromProps } from '../../components/track-changes/src/MoveFrom.ts';
+import type { MoveToProps } from '../../components/track-changes/src/MoveTo.ts';
 import type { ChangeInformation } from '../../utilities/src/changes.ts';
 import { create } from '../../utilities/src/dom.ts';
 import type { Length } from '../../utilities/src/length.ts';
@@ -140,7 +144,7 @@ export type TextProperties = {
 	 *
 	 * Read more here:  https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_moveTo_topic_ID0EXMJW.html
 	 */
-	move?: MoveProps | null;
+	move?: MoveToProps | MoveFromProps | null;
 
 	/**
 	 * A property used to indicate that the way this text is deiplayed has changed somehow.
@@ -428,7 +432,15 @@ export async function textPropertiesToNode(
 			 * since the move information is sent as properties rather than as an
 			 * object, we can be sure that no more children will ever be created.
 			 */
-			move: data.move ? await new Move(data.move).toNode([]) : null,
+			move: data.move
+				? {
+						id: data.move.id,
+						date: data.move.date
+							? new Date(data.move.date).toISOString()
+							: undefined,
+						author: data.move.author ? data.move.author : undefined,
+				  }
+				: null,
 			insertion: data.insertion
 				? await new Insertion(data.insertion).toNode([])
 				: null,

--- a/lib/properties/src/text-properties.ts
+++ b/lib/properties/src/text-properties.ts
@@ -447,7 +447,7 @@ export async function textPropertiesToNode(
 				  }
 				: null,
 			/*
-			 * Although the Move and Insertion components are used here and it can have children,
+			 * Although the MoveTo, MoveFrom and Insertion components are used here and it can have children,
 			 * since the move information is sent as properties rather than as an
 			 * object, we can be sure that no more children will ever be created.
 			 */

--- a/lib/properties/src/text-properties.ts
+++ b/lib/properties/src/text-properties.ts
@@ -294,14 +294,16 @@ export function textPropertiesFromNode(node?: Node | null): TextProperties {
 
 	if (props.moveTo) {
 		props.moveTo = {
-			...props.moveTo,
+			id: props.moveTo.id,
+			author: props.moveTo.author ? props.moveTo.author : undefined,
 			date: props.moveTo.date ? new Date(props.moveTo.date) : undefined,
 		};
 	}
 
 	if (props.moveFrom) {
 		props.moveFrom = {
-			...props.moveFrom,
+			id: props.moveFrom.id,
+			author: props.moveFrom.author ? props.moveFrom.author : undefined,
 			date: props.moveFrom.date
 				? new Date(props.moveFrom.date)
 				: undefined,

--- a/lib/properties/src/text-properties.ts
+++ b/lib/properties/src/text-properties.ts
@@ -1,10 +1,4 @@
-import {
-	Deletion,
-	Insertion,
-	MoveFrom,
-	MoveTo,
-	type InsertionProps,
-} from '../../../mod.ts';
+import { Deletion, Insertion, type InsertionProps } from '../../../mod.ts';
 import type { MoveFromProps } from '../../components/track-changes/src/MoveFrom.ts';
 import type { MoveToProps } from '../../components/track-changes/src/MoveTo.ts';
 import type { ChangeInformation } from '../../utilities/src/changes.ts';
@@ -144,7 +138,8 @@ export type TextProperties = {
 	 *
 	 * Read more here:  https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_moveTo_topic_ID0EXMJW.html
 	 */
-	move?: MoveToProps | MoveFromProps | null;
+	moveTo?: MoveToProps | null;
+	moveFrom?: MoveFromProps | null;
 
 	/**
 	 * A property used to indicate that the way this text is deiplayed has changed somehow.
@@ -225,12 +220,16 @@ export function textPropertiesFromNode(node?: Node | null): TextProperties {
 				"ascii": @${QNS.w}ascii/string(),
 				"hAnsi": @${QNS.w}hAnsi/string()
 			},
-			"move": ./${QNS.w}*[self::${QNS.w}moveTo or self::${QNS.w}moveFrom]/map {
+			"moveTo": ./${QNS.w}moveTo/map {
 				"id": @${QNS.w}id/number(), 
 				"author": @${QNS.w}author/string(), 
 				"date": @${QNS.w}date/string(),
-				"type": if ($nodeName eq 'moveTo') then 'to' else 'from'
 			}, 
+			"moveFrom": ./${QNS.w}moveFrom/map { 
+				"id": @${QNS.w}id/number(), 
+				"author": @${QNS.w}author/string(), 
+				"date": @${QNS.w}date/string(),
+			},
 			"change": ./${QNS.w}rPrChange/map { 
 				"id": @${QNS.w}id/number(), 
 				"author": @${QNS.w}author/string(), 
@@ -287,12 +286,20 @@ export function textPropertiesFromNode(node?: Node | null): TextProperties {
 		};
 	}
 
-	if (props.move) {
-		// Convert the date string to a Date object.
-		props.move.date = props.move.date
-			? new Date(props.move.date)
-			: undefined;
-		props.move.author = props.move.author ? props.move.author : undefined;
+	if (props.moveTo) {
+		props.moveTo = {
+			...props.moveTo,
+			date: props.moveTo.date ? new Date(props.moveTo.date) : undefined,
+		};
+	}
+
+	if (props.moveFrom) {
+		props.moveFrom = {
+			...props.moveFrom,
+			date: props.moveFrom.date
+				? new Date(props.moveFrom.date)
+				: undefined,
+		};
 	}
 
 	return props as TextProperties;
@@ -315,7 +322,8 @@ export async function textPropertiesToNode(
 		!data.isStrike &&
 		!data.shading &&
 		!data.font &&
-		!data.move &&
+		!data.moveTo &&
+		!data.moveFrom &&
 		!data.change &&
 		!data.insertion &&
 		!data.deletion
@@ -432,13 +440,27 @@ export async function textPropertiesToNode(
 			 * since the move information is sent as properties rather than as an
 			 * object, we can be sure that no more children will ever be created.
 			 */
-			move: data.move
+			moveTo: data.moveTo
 				? {
-						id: data.move.id,
-						date: data.move.date
-							? new Date(data.move.date).toISOString()
+						id: data.moveTo.id,
+						date: data.moveTo.date
+							? new Date(data.moveTo.date).toISOString()
 							: undefined,
-						author: data.move.author ? data.move.author : undefined,
+						author: data.moveTo.author
+							? data.moveTo.author
+							: undefined,
+				  }
+				: null,
+
+			moveFrom: data.moveFrom
+				? {
+						id: data.moveFrom.id,
+						date: data.moveFrom.date
+							? new Date(data.moveFrom.date).toISOString()
+							: undefined,
+						author: data.moveFrom.author
+							? data.moveFrom.author
+							: undefined,
 				  }
 				: null,
 			insertion: data.insertion

--- a/lib/properties/src/text-properties.ts
+++ b/lib/properties/src/text-properties.ts
@@ -1,6 +1,12 @@
 import { Deletion, Insertion, type InsertionProps } from '../../../mod.ts';
-import type { MoveFromProps } from '../../components/track-changes/src/MoveFrom.ts';
-import type { MoveToProps } from '../../components/track-changes/src/MoveTo.ts';
+import {
+	MoveFrom,
+	type MoveFromProps,
+} from '../../components/track-changes/src/MoveFrom.ts';
+import {
+	MoveTo,
+	type MoveToProps,
+} from '../../components/track-changes/src/MoveTo.ts';
 import type { ChangeInformation } from '../../utilities/src/changes.ts';
 import { create } from '../../utilities/src/dom.ts';
 import type { Length } from '../../utilities/src/length.ts';
@@ -136,8 +142,8 @@ export type TextProperties = {
 	 *
 	 * If present, the containing paragraph element will appear as a track-change moved paragraph.
 	 *
-	 * Read more here:  https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_moveTo_topic_ID0EXMJW.html
-	 */
+	 * Read more here:  https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_moveTo_topic_ID0EE3IW.html
+	 **/
 	moveTo?: MoveToProps | null;
 	moveFrom?: MoveFromProps | null;
 
@@ -223,16 +229,16 @@ export function textPropertiesFromNode(node?: Node | null): TextProperties {
 			"moveTo": ./${QNS.w}moveTo/map {
 				"id": @${QNS.w}id/number(), 
 				"author": @${QNS.w}author/string(), 
-				"date": @${QNS.w}date/string(),
+				"date": @${QNS.w}date/string()
 			}, 
 			"moveFrom": ./${QNS.w}moveFrom/map { 
 				"id": @${QNS.w}id/number(), 
 				"author": @${QNS.w}author/string(), 
-				"date": @${QNS.w}date/string(),
+				"date": @${QNS.w}date/string()
 			},
 			"change": ./${QNS.w}rPrChange/map { 
 				"id": @${QNS.w}id/number(), 
-				"author": @${QNS.w}author/string(), 
+				"author": if (@${QNS.w}author/string()) then @${QNS.w}author/string() else (), 
 				"date": @${QNS.w}date/string(), 
 				"node": ./${QNS.w}rPr
 			},
@@ -385,7 +391,8 @@ export async function textPropertiesToNode(
 				if ($change('author')) then attribute ${QNS.w}author { $change('author') } else (),
 				$change('node')
 			} else (),
-			$move,
+			$moveTo, 
+			$moveFrom,
 			$insertion,
 			$deletion
 		}`,
@@ -441,27 +448,24 @@ export async function textPropertiesToNode(
 			 * object, we can be sure that no more children will ever be created.
 			 */
 			moveTo: data.moveTo
-				? {
-						id: data.moveTo.id,
-						date: data.moveTo.date
-							? new Date(data.moveTo.date).toISOString()
-							: undefined,
+				? await new MoveTo({
+						...data.moveTo,
 						author: data.moveTo.author
 							? data.moveTo.author
 							: undefined,
-				  }
+						date: data.moveTo.date
+							? new Date(data.moveTo.date)
+							: undefined,
+				  }).toNode([])
 				: null,
 
 			moveFrom: data.moveFrom
-				? {
-						id: data.moveFrom.id,
+				? await new MoveFrom({
+						...data.moveFrom,
 						date: data.moveFrom.date
-							? new Date(data.moveFrom.date).toISOString()
+							? new Date(data.moveFrom.date)
 							: undefined,
-						author: data.moveFrom.author
-							? data.moveFrom.author
-							: undefined,
-				  }
+				  }).toNode([])
 				: null,
 			insertion: data.insertion
 				? await new Insertion(data.insertion).toNode([])

--- a/lib/properties/test/text-properties.test.ts
+++ b/lib/properties/test/text-properties.test.ts
@@ -62,9 +62,8 @@ describe('Text formatting', () => {
 				ascii: 'Arial',
 				hAnsi: 'Courier New',
 			},
-			move: {
+			moveTo: {
 				author: 'Gabe',
-				type: 'to',
 				date: date,
 				id: 1,
 			},
@@ -140,9 +139,8 @@ describe('Change Information properties', () => {
 			</w:rPrChange>
 		</w:rPr>`,
 		{
-			move: {
+			moveTo: {
 				author: 'Gabe',
-				type: 'to',
 				date: date,
 				id: 1,
 			},
@@ -169,8 +167,7 @@ describe('Change Information properties', () => {
 				</w:rPrChange>
 			</w:rPr>`,
 		{
-			move: {
-				type: 'to',
+			moveTo: {
 				date: date,
 				id: 1,
 			},
@@ -196,8 +193,7 @@ describe('Change Information properties', () => {
 				</w:rPrChange>
 			</w:rPr>`,
 		{
-			move: {
-				type: 'to',
+			moveTo: {
 				author: 'Gabe',
 				id: 1,
 			},
@@ -223,8 +219,7 @@ describe('Change Information properties', () => {
 				</w:rPrChange>
 				</w:rPr>`,
 		{
-			move: {
-				type: 'to',
+			moveTo: {
 				id: 1,
 			},
 			change: {

--- a/lib/properties/test/text-properties.test.ts
+++ b/lib/properties/test/text-properties.test.ts
@@ -76,6 +76,40 @@ describe('Text formatting', () => {
 			},
 		}
 	);
+
+	test(
+		`<w:rPr ${ALL_NAMESPACE_DECLARATIONS}>
+			<w:color w:val="red" />
+			<w:b />
+			<w:i />
+			<w:vertAlign w:val="subscript" />
+			<w:moveFrom w:author="Gabe" w:date="${date.toISOString()}" w:id="1" /> 
+			<w:rPrChange w:author="Angel" w:date="${date.toISOString()}" w:id="99" > 
+				<w:rPr>
+					<w:color w:val="blue" /> 
+					<w:b w:val="false" /> 
+				</w:rPr>
+			</w:rPrChange>
+		</w:rPr>`,
+		{
+			color: 'red',
+			isBold: { simple: true, complex: false },
+			isItalic: { simple: true, complex: false },
+			verticalAlign: 'subscript',
+			moveFrom: {
+				author: 'Gabe',
+				date: date,
+				id: 1,
+			},
+			change: {
+				author: 'Angel',
+				date: date,
+				id: 99,
+				color: 'blue',
+				isBold: { simple: false, complex: false },
+			},
+		}
+	);
 });
 
 describe('Complex character formatting', () => {

--- a/mod.ts
+++ b/mod.ts
@@ -141,10 +141,10 @@ export {
 	type InsertionProps,
 } from './lib/components/track-changes/src/Insertion.ts';
 export {
-	Move,
-	type MoveChild,
-	type MoveProps,
-} from './lib/components/track-changes/src/Move.ts';
+	MoveFrom,
+	type MoveFromChild,
+	type MoveFromProps,
+} from './lib/components/track-changes/src/MoveFrom.ts';
 export {
 	MoveFromRangeEnd,
 	type MoveFromRangeEndChild,
@@ -155,6 +155,11 @@ export {
 	type MoveFromRangeStartChild,
 	type MoveFromRangeStartProps,
 } from './lib/components/track-changes/src/MoveFromRangeStart.ts';
+export {
+	MoveTo,
+	type MoveToChild,
+	type MoveToProps,
+} from './lib/components/track-changes/src/MoveTo.ts';
 export {
 	MoveToRangeEnd,
 	type MoveRangeEndChild,


### PR DESCRIPTION
This PR splits our current `move` component with its `type: 'to' | 'from'` property into two separate components: 
- `moveTo` and 
- `moveFrom` 
This more closely matches OOXML and also makes things easier for Fonto Output's implementation. 