### PR TITLE
DEV-26740 Improvements when importing cells, images, links and styles

### DIFF
--- a/lib/components/document/src/Cell.ts
+++ b/lib/components/document/src/Cell.ts
@@ -218,6 +218,13 @@ export class Cell extends Component<CellProps, CellChild> {
 		node: Node,
 		context: ComponentContext
 	): null | Cell {
+		/*
+		 * Note: This code is similar to tableCellPropertiesFromNode().
+		 * In other elements (Table for example), this code reuses the tableXPropertiesFromNode() functions.
+		 * But in this case there are slight differences: $firstNextRow logic, $mergeCells and props.changes.
+		 * We should consider aligning both.
+		 */
+
 		const { mergedAway, children, ...props } = evaluateXPathToMap<
 			CellProps & { mergedAway: boolean; children: Node[] }
 		>(
@@ -248,6 +255,17 @@ export class Cell extends Component<CellProps, CellChild> {
 						else 1,
 					"rowSpan": $rowEnd - $rowStart,
 					"children": array{ ./(${QNS.w}p) },
+					"shading": ./${QNS.w}tcPr/${QNS.w}shd/docxml:ct-shd(.),
+					"borders": ./${QNS.w}tcPr/${QNS.w}tcBorders/map {
+						"top": docxml:ct-border(${QNS.w}top),
+						"start": docxml:ct-border((${QNS.w}start|${QNS.w}left)[1]),
+						"bottom": docxml:ct-border(${QNS.w}bottom),
+						"end": docxml:ct-border((${QNS.w}end|${QNS.w}right)[1]),
+						"tl2br": docxml:ct-border(${QNS.w}tl2br),
+						"tr2bl": docxml:ct-border(${QNS.w}tr2bl),
+						"insideH": docxml:ct-border(${QNS.w}insideH),
+						"insideV": docxml:ct-border(${QNS.w}insideV)
+					},
 					"verticalAlignment": ./${QNS.w}tcPr/${QNS.w}vAlign/@${QNS.w}val/string(),
 					"insertion": ./${QNS.w}tcPr/${QNS.w}cellIns/map {
 						"id": @${QNS.w}id/number(),

--- a/lib/components/document/src/Hyperlink.ts
+++ b/lib/components/document/src/Hyperlink.ts
@@ -34,21 +34,26 @@ export type HyperlinkProps =
 			bookmark?: never;
 			url?: never;
 			tooltip?: string;
-			id?: string;
+			/**
+			 * RelationshipId when the hyperlink is imported from an existing DOCX file.
+			 * This is used to preserve the relationship when re-serializing the file,
+			 * and should not be set manually when creating new hyperlinks.
+			 */
+			relationshipId?: string;
 	  }
 	| {
 			anchor?: never;
 			bookmark: Bookmark;
 			url?: never;
 			tooltip?: string;
-			id?: string;
+			relationshipId?: string;
 	  }
 	| {
 			anchor?: never;
 			bookmark?: never;
 			url: string;
 			tooltip?: string;
-			id?: string;
+			relationshipId?: string;
 	  };
 
 /**
@@ -114,7 +119,7 @@ export class Hyperlink extends Component<HyperlinkProps, HyperlinkChild> {
 			HyperlinkProps & { children: Node[] }
 		>(
 			`map {
-				"id": ./@${QNS.r}id/string(),
+				"relationshipId": ./@${QNS.r}id/string(),
 				"anchor": ./@${QNS.w}anchor/string(),
 				"tooltip": ./@${QNS.w}tooltip/string(),
 				"children": array{ ./(
@@ -127,9 +132,9 @@ export class Hyperlink extends Component<HyperlinkProps, HyperlinkChild> {
 			node
 		);
 
-		if (props.id) {
+		if (props.relationshipId) {
 			// if it is an external, the url (target) is stored in the relationships file.
-			props.url = context.relationships?.getTarget(props.id);
+			props.url = context.relationships?.getTarget(props.relationshipId);
 		}
 
 		return new Hyperlink(

--- a/lib/components/document/src/Hyperlink.ts
+++ b/lib/components/document/src/Hyperlink.ts
@@ -34,18 +34,21 @@ export type HyperlinkProps =
 			bookmark?: never;
 			url?: never;
 			tooltip?: string;
+			id?: string;
 	  }
 	| {
 			anchor?: never;
 			bookmark: Bookmark;
 			url?: never;
 			tooltip?: string;
+			id?: string;
 	  }
 	| {
 			anchor?: never;
 			bookmark?: never;
 			url: string;
 			tooltip?: string;
+			id?: string;
 	  };
 
 /**
@@ -111,6 +114,7 @@ export class Hyperlink extends Component<HyperlinkProps, HyperlinkChild> {
 			HyperlinkProps & { children: Node[] }
 		>(
 			`map {
+				"id": ./@${QNS.r}id/string(),
 				"anchor": ./@${QNS.w}anchor/string(),
 				"tooltip": ./@${QNS.w}tooltip/string(),
 				"children": array{ ./(
@@ -122,6 +126,12 @@ export class Hyperlink extends Component<HyperlinkProps, HyperlinkChild> {
 			}`,
 			node
 		);
+
+		if (props.id) {
+			// if it is an external, the url (target) is stored in the relationships file.
+			props.url = context.relationships?.getTarget(props.id);
+		}
+
 		return new Hyperlink(
 			props,
 			...createChildComponentsFromNodes<HyperlinkChild>(

--- a/lib/components/document/src/Image.ts
+++ b/lib/components/document/src/Image.ts
@@ -44,6 +44,12 @@ export type ImageProps = {
 	alt?: null | string;
 	width: Length;
 	height: Length;
+	/**
+	 * RelationshipId when the image is imported from an existing DOCX file.
+	 * This is used to preserve the relationship when re-serializing the file,
+	 * and should not be set manually when creating new images.
+	 */
+	relationshipId?: string;
 };
 
 /**
@@ -129,7 +135,7 @@ export class Image extends Component<ImageProps, ImageChild> {
 		this.#meta = {
 			location: `word/media/${createRandomId('img')}`,
 			mime: props.mime ? Promise.resolve(props.mime) : null,
-			relationshipId: null,
+			relationshipId: props.relationshipId || null,
 			extensions: {},
 		};
 
@@ -179,14 +185,11 @@ export class Image extends Component<ImageProps, ImageChild> {
 	 * Creates an XML DOM node for this component instance.
 	 */
 	public override toNode(_ancestry: ComponentAncestor[]): Node {
-		/**
-		 * @Todo This breaks word input if there are images.... why??
-		 */
-		// if (!this.#meta.relationshipId) {
-		// 	throw new Error(
-		// 		'Cannot serialize an image outside the context of an Document'
-		// 	);
-		// }
+		if (!this.#meta.relationshipId) {
+			throw new Error(
+				'Cannot serialize an image outside the context of an Document'
+			);
+		}
 
 		let extensionList: Node | null = null;
 		const { svg } = this.meta.extensions;
@@ -358,6 +361,7 @@ export class Image extends Component<ImageProps, ImageChild> {
 			title,
 			width,
 			height,
+			relationshipId: main.relationshipId,
 		});
 		image.#meta.location = main.location;
 		if (svg) {
@@ -377,6 +381,7 @@ type ExtractedBlipNodeData = {
 	main: {
 		data: Promise<Uint8Array>;
 		location: string;
+		relationshipId?: string;
 	};
 	svg?: {
 		data: Promise<string>;
@@ -400,6 +405,7 @@ function extractDataFromBlipNode(
 		main: {
 			data,
 			location,
+			relationshipId: blipEmbedRel,
 		},
 	};
 

--- a/lib/components/document/src/Image.ts
+++ b/lib/components/document/src/Image.ts
@@ -179,11 +179,14 @@ export class Image extends Component<ImageProps, ImageChild> {
 	 * Creates an XML DOM node for this component instance.
 	 */
 	public override toNode(_ancestry: ComponentAncestor[]): Node {
-		if (!this.#meta.relationshipId) {
-			throw new Error(
-				'Cannot serialize an image outside the context of an Document'
-			);
-		}
+		/**
+		 * @Todo This breaks word input if there are images.... why??
+		 */
+		// if (!this.#meta.relationshipId) {
+		// 	throw new Error(
+		// 		'Cannot serialize an image outside the context of an Document'
+		// 	);
+		// }
 
 		let extensionList: Node | null = null;
 		const { svg } = this.meta.extensions;

--- a/lib/enums.ts
+++ b/lib/enums.ts
@@ -55,6 +55,7 @@ export enum RelationshipType {
 	commentsExtended = 'http://schemas.microsoft.com/office/2011/relationships/commentsExtended',
 	corePropertiesAlternative = 'http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties',
 	coreProperties = 'http://schemas.openxmlformats.org/officedocument/2006/relationships/metadata/core-properties',
+
 	customProperties = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/custom-properties',
 	customXml = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/customXml',
 	endnotes = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes',
@@ -79,4 +80,11 @@ export enum RelationshipType {
 	// Legacy template (.dot)
 	downRev = 'http://schemas.microsoft.com/office/2006/relationships/downRev',
 	graphicFrameDoc = 'http://schemas.microsoft.com/office/2006/relationships/graphicFrameDoc',
+	/**
+	 * @todo Decide how to implement these two new relationships.
+	 * Info (?) about thumbnail: https://c-rex.net/samples/ooxml/e1/Part1/OOXML_P1_Fundamentals_Thumbnail_topic_ID0EWLEO.html?hl=thumbnail
+	 * I guess that something like "CorePropertiesXml.ts" has to be created.
+	 */
+	thumbnail = 'http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail',
+	stylesWithEffects = 'http://schemas.microsoft.com/office/2007/relationships/stylesWithEffects',
 }

--- a/lib/enums.ts
+++ b/lib/enums.ts
@@ -80,9 +80,10 @@ export enum RelationshipType {
 	// Legacy template (.dot)
 	downRev = 'http://schemas.microsoft.com/office/2006/relationships/downRev',
 	graphicFrameDoc = 'http://schemas.microsoft.com/office/2006/relationships/graphicFrameDoc',
-	/**
-	 * @todo Decide how to implement these two new relationships.
-	 * Info (?) about thumbnail: https://c-rex.net/samples/ooxml/e1/Part1/OOXML_P1_Fundamentals_Thumbnail_topic_ID0EWLEO.html?hl=thumbnail
+	/*
+	 * thumbnail and stylesWithEffects are relationships that are not yet known.
+	 * For the time being, they will be treated as such in lib > files > index.ts.
+	 * Info about thumbnail: https://c-rex.net/samples/ooxml/e1/Part1/OOXML_P1_Fundamentals_Thumbnail_topic_ID0EWLEO.html?hl=thumbnail
 	 * I guess that something like "CorePropertiesXml.ts" has to be created.
 	 */
 	thumbnail = 'http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail',

--- a/lib/files/src/DocumentXml.ts
+++ b/lib/files/src/DocumentXml.ts
@@ -144,7 +144,7 @@ export class DocumentXml extends XmlFileWithContentTypes {
 	 * Use this with caution, as this XML may differ from the
 	 * content of DocumentXml as soon as it is used.
 	 */
-	#initialRawXml: Document | null = null;
+	#xml: Document | null = null;
 
 	/**
 	 * The API representing the raw XML content of "document.xml"
@@ -152,15 +152,15 @@ export class DocumentXml extends XmlFileWithContentTypes {
 	 * Use this with caution, as this XML may differ from the content
 	 * of DocumentXml as soon as it is used.
 	 */
-	public get initialRawXml(): Document | null {
-		return this.#initialRawXml;
+	public get xml(): Document | null {
+		return this.#xml;
 	}
 
 	/**
 	 * Set the raw XML content of "document.xml".
 	 */
-	public set initialRawXml(document: Document) {
-		this.#initialRawXml = document;
+	protected set xml(document: Document) {
+		this.#xml = document;
 	}
 
 	/**
@@ -287,7 +287,7 @@ export class DocumentXml extends XmlFileWithContentTypes {
 		);
 		const doc = new DocumentXml(location, relationships);
 		const dom = await archive.readXml(location);
-		doc.initialRawXml = dom;
+		doc.xml = dom; // Store the initial xml
 		const sections = evaluateXPathToNodes(
 			`/*/${QNS.w}body/(${QNS.w}p/${QNS.w}pPr/${QNS.w}sectPr | ${QNS.w}sectPr)`,
 			dom

--- a/lib/files/src/DocumentXml.ts
+++ b/lib/files/src/DocumentXml.ts
@@ -140,6 +140,30 @@ export class DocumentXml extends XmlFileWithContentTypes {
 	}
 
 	/**
+	 * document.xml content as it was imported using .fromArchive().
+	 * Use this with caution, as this XML may differ from the
+	 * content of DocumentXml as soon as it is used.
+	 */
+	#initialRawXml: Document | null = null;
+
+	/**
+	 * The API representing the raw XML content of "document.xml"
+	 * as it was imported using .fromArchive().
+	 * Use this with caution, as this XML may differ from the content
+	 * of DocumentXml as soon as it is used.
+	 */
+	public get initialRawXml(): Document | null {
+		return this.#initialRawXml;
+	}
+
+	/**
+	 * Set the raw XML content of "document.xml".
+	 */
+	public set initialRawXml(document: Document) {
+		this.#initialRawXml = document;
+	}
+
+	/**
 	 * The components normalized from #root, which is potentially arrayed, promised, array promised etc.
 	 */
 	public get children(): Promise<DocumentChild[]> {
@@ -162,10 +186,9 @@ export class DocumentXml extends XmlFileWithContentTypes {
 									flatten,
 									Promise.resolve([])
 								)),
-						  ]
+							]
 						: [...flat, child];
-				},
-				Promise.resolve([]))
+				}, Promise.resolve([]))
 			);
 	}
 
@@ -264,6 +287,7 @@ export class DocumentXml extends XmlFileWithContentTypes {
 		);
 		const doc = new DocumentXml(location, relationships);
 		const dom = await archive.readXml(location);
+		doc.initialRawXml = dom;
 		const sections = evaluateXPathToNodes(
 			`/*/${QNS.w}body/(${QNS.w}p/${QNS.w}pPr/${QNS.w}sectPr | ${QNS.w}sectPr)`,
 			dom
@@ -279,7 +303,7 @@ export class DocumentXml extends XmlFileWithContentTypes {
 						sectionChildComponentNames,
 						evaluateXPathToNodes(`/*/${QNS.w}body/*`, dom),
 						context
-				  )
+					)
 		);
 		return doc;
 	}

--- a/lib/files/src/StylesXml.ts
+++ b/lib/files/src/StylesXml.ts
@@ -253,6 +253,13 @@ export class StylesXml extends XmlFile {
 	}
 
 	/**
+	 * Makes accessible the default styles for this document outside of this library.
+	 */
+	public getDefaultStyles(): DocumentDefaults {
+		return this.#docDefaultStyles;
+	}
+
+	/**
 	 * Adds a latent style, which means that the Word processor should determine its actual properties
 	 */
 	public addLatent(properties: LatentStyle): void {
@@ -412,20 +419,6 @@ export class StylesXml extends XmlFile {
 							}
 						: {}),
 				};
-
-				if (json.isDefault) {
-					// Should these properties be added to any style that does not have values defined for them?
-					if (json.type === 'paragraph') {
-						// Should paragraph type add default text properties as well?
-						instance.addDefaultPropertiesToParagraphProperties(
-							paragraphProperties
-						);
-					} else if (json.type === 'character') {
-						instance.addDefaultPropertiesToTextProperties(
-							runProperties
-						);
-					}
-				}
 
 				return {
 					...json,

--- a/lib/files/src/StylesXml.ts
+++ b/lib/files/src/StylesXml.ts
@@ -414,6 +414,7 @@ export class StylesXml extends XmlFile {
 				};
 
 				if (json.isDefault) {
+					// Should these properties be added to any style that does not have values defined for them?
 					if (json.type === 'paragraph') {
 						// Should paragraph type add default text properties as well?
 						instance.addDefaultPropertiesToParagraphProperties(

--- a/lib/files/src/StylesXml.ts
+++ b/lib/files/src/StylesXml.ts
@@ -243,6 +243,13 @@ export class StylesXml extends XmlFile {
 	}
 
 	/**
+	 * Makes accessible the default styles for this document outside of this library.
+	 */
+	public get docDefaultStyles(): DocumentDefaults {
+		return this.#docDefaultStyles;
+	}
+
+	/**
 	 * Adds default styles.
 	 */
 	public addDefaults(properties: DocumentDefaults): void {
@@ -250,13 +257,6 @@ export class StylesXml extends XmlFile {
 			properties.defaultRunProperties;
 		this.#docDefaultStyles.defaultParagraphProperties =
 			properties.defaultParagraphProperties;
-	}
-
-	/**
-	 * Makes accessible the default styles for this document outside of this library.
-	 */
-	public getDefaultStyles(): DocumentDefaults {
-		return this.#docDefaultStyles;
 	}
 
 	/**

--- a/lib/files/src/StylesXml.ts
+++ b/lib/files/src/StylesXml.ts
@@ -276,6 +276,59 @@ export class StylesXml extends XmlFile {
 		return this.#styles.find((style) => style.id === id);
 	}
 
+	private addDefaultPropertiesToTextProperties(
+		runProperties: TextProperties
+	): void {
+		// FONT
+		const defaultFont = this.#docDefaultStyles?.defaultRunProperties?.font;
+		if (runProperties.font === undefined || runProperties.font === null) {
+			runProperties.font = defaultFont;
+		}
+		if (runProperties.font && typeof runProperties.font !== 'string') {
+			for (const key in runProperties.font) {
+				if (
+					runProperties.font[key as keyof TextProperties['font']] ===
+						null &&
+					defaultFont &&
+					typeof defaultFont !== 'string'
+				) {
+					runProperties.font[key as keyof TextProperties['font']] =
+						defaultFont[key as keyof TextProperties['font']];
+				}
+			}
+		}
+
+		// FONT SIZE
+		/**
+		 * @improve like font
+		 */
+		const defaultFontSize =
+			this.#docDefaultStyles?.defaultRunProperties?.fontSize;
+		if (
+			runProperties.fontSize === undefined ||
+			runProperties.fontSize === null
+		) {
+			runProperties.fontSize = defaultFontSize;
+		}
+	}
+
+	private addDefaultPropertiesToParagraphProperties(
+		paragraphProperties: ParagraphProperties
+	): void {
+		// SPACING
+		/**
+		 * @improve like font
+		 */
+		const defaultSpacing =
+			this.#docDefaultStyles?.defaultParagraphProperties?.spacing;
+		if (
+			paragraphProperties.spacing === undefined ||
+			paragraphProperties.spacing === null
+		) {
+			paragraphProperties.spacing = defaultSpacing;
+		}
+	}
+
 	public static fromDom(
 		dom: Document,
 		location: string,
@@ -301,7 +354,7 @@ export class StylesXml extends XmlFile {
 			defaultParagraphProperties: defaultParagraphProperties,
 		} as DocumentDefaults);
 
-		//We should not get here unless there's *NOTHING* telling us what to do.
+		// We should not get here unless there's *NOTHING* telling us what to do.
 		let instanceFontProperties: TextProperties['font'] =
 			instance.#docDefaultStyles?.defaultRunProperties?.font;
 		if (
@@ -340,59 +393,44 @@ export class StylesXml extends XmlFile {
 				dom
 			).map(({ ppr, rpr, tblpr, tblStylePr, ...json }) => {
 				const runProperties = textPropertiesFromNode(rpr);
-				const instanceFont =
-					instance.#docDefaultStyles?.defaultRunProperties?.font;
-				if (json.isDefault) {
-					if (
-						runProperties.font === undefined ||
-						runProperties.font === null
-					) {
-						runProperties.font = instanceFont;
-					}
-					if (
-						runProperties.font &&
-						typeof runProperties.font !== 'string'
-					) {
-						for (const key in runProperties.font) {
-							if (
-								runProperties.font[
-									key as keyof TextProperties['font']
-								] === null &&
-								instanceFont &&
-								typeof instanceFont !== 'string'
-							) {
-								runProperties.font[
-									key as keyof TextProperties['font']
-								] =
-									instanceFont[
-										key as keyof TextProperties['font']
-									];
+				const paragraphProperties = paragraphPropertiesFromNode(ppr);
+				const tableProperties = {
+					...tablePropertiesFromNode(tblpr),
+					...(tblStylePr.length
+						? {
+								conditions: (
+									tblStylePr.map(
+										tableConditionalPropertiesFromNode
+									) as TableConditionalProperties[]
+								).reduce(
+									(m, { type, ...style }) =>
+										Object.assign(m, {
+											[type]: style,
+										}),
+									{}
+								),
 							}
-						}
+						: {}),
+				};
+
+				if (json.isDefault) {
+					if (json.type === 'paragraph') {
+						// Should paragraph type add default text properties as well?
+						instance.addDefaultPropertiesToParagraphProperties(
+							paragraphProperties
+						);
+					} else if (json.type === 'character') {
+						instance.addDefaultPropertiesToTextProperties(
+							runProperties
+						);
 					}
 				}
+
 				return {
 					...json,
-					paragraph: paragraphPropertiesFromNode(ppr),
+					paragraph: paragraphProperties,
 					text: runProperties,
-					table: {
-						...tablePropertiesFromNode(tblpr),
-						...(tblStylePr.length
-							? {
-									conditions: (
-										tblStylePr.map(
-											tableConditionalPropertiesFromNode
-										) as TableConditionalProperties[]
-									).reduce(
-										(m, { type, ...style }) =>
-											Object.assign(m, {
-												[type]: style,
-											}),
-										{}
-									),
-								}
-							: {}),
-					},
+					table: tableProperties,
 				};
 			})
 		);

--- a/lib/files/src/StylesXml.ts
+++ b/lib/files/src/StylesXml.ts
@@ -283,59 +283,6 @@ export class StylesXml extends XmlFile {
 		return this.#styles.find((style) => style.id === id);
 	}
 
-	private addDefaultPropertiesToTextProperties(
-		runProperties: TextProperties
-	): void {
-		// FONT
-		const defaultFont = this.#docDefaultStyles?.defaultRunProperties?.font;
-		if (runProperties.font === undefined || runProperties.font === null) {
-			runProperties.font = defaultFont;
-		}
-		if (runProperties.font && typeof runProperties.font !== 'string') {
-			for (const key in runProperties.font) {
-				if (
-					runProperties.font[key as keyof TextProperties['font']] ===
-						null &&
-					defaultFont &&
-					typeof defaultFont !== 'string'
-				) {
-					runProperties.font[key as keyof TextProperties['font']] =
-						defaultFont[key as keyof TextProperties['font']];
-				}
-			}
-		}
-
-		// FONT SIZE
-		/**
-		 * @improve like font
-		 */
-		const defaultFontSize =
-			this.#docDefaultStyles?.defaultRunProperties?.fontSize;
-		if (
-			runProperties.fontSize === undefined ||
-			runProperties.fontSize === null
-		) {
-			runProperties.fontSize = defaultFontSize;
-		}
-	}
-
-	private addDefaultPropertiesToParagraphProperties(
-		paragraphProperties: ParagraphProperties
-	): void {
-		// SPACING
-		/**
-		 * @improve like font
-		 */
-		const defaultSpacing =
-			this.#docDefaultStyles?.defaultParagraphProperties?.spacing;
-		if (
-			paragraphProperties.spacing === undefined ||
-			paragraphProperties.spacing === null
-		) {
-			paragraphProperties.spacing = defaultSpacing;
-		}
-	}
-
 	public static fromDom(
 		dom: Document,
 		location: string,

--- a/lib/files/src/index.ts
+++ b/lib/files/src/index.ts
@@ -69,7 +69,7 @@ export function castRelationshipToClass(
 		case RelationshipType.graphicFrameDoc:
 		case RelationshipType.glossary:
 		/**
-		 * @todo Implement these relationships. Check enum.ts
+		 * @todo Implement these relationships. Check enums.ts
 		 */
 		case RelationshipType.thumbnail:
 		case RelationshipType.stylesWithEffects:

--- a/lib/files/src/index.ts
+++ b/lib/files/src/index.ts
@@ -68,6 +68,11 @@ export function castRelationshipToClass(
 		case RelationshipType.downRev:
 		case RelationshipType.graphicFrameDoc:
 		case RelationshipType.glossary:
+		/**
+		 * @todo Implement these relationships. Check enum.ts
+		 */
+		case RelationshipType.thumbnail:
+		case RelationshipType.stylesWithEffects:
 			return UnhandledXmlFile.fromArchive(archive, meta.target);
 
 		case RelationshipType.attachedTemplate:


### PR DESCRIPTION
- Borders properties have been added for cells. Custom borders are now processed per cell.
- Images: Set the relationship when the image is imported.
- Hyperlink: Set the URL when importing based on the relationship ID.
- Two unknown relationships have been added: 'thumbnail' and 'stylesWithEffects'.
- Publicly exposed default styles.