### PR TITLE
DEV-26859 Replace exactly with exact for lineRule

### DIFF
--- a/lib/properties/src/paragraph-properties.ts
+++ b/lib/properties/src/paragraph-properties.ts
@@ -52,7 +52,7 @@ export type ParagraphProperties = {
 		before?: Length | null;
 		after?: Length | null;
 		line?: Length | null;
-		lineRule?: 'atLeast' | 'exactly' | 'auto' | null;
+		lineRule?: 'atLeast' | 'exact' | 'auto' | null;
 		afterAutoSpacing?: boolean | null;
 		beforeAutoSpacing?: boolean | null;
 	} | null;

--- a/lib/properties/test/paragraph-properties.test.ts
+++ b/lib/properties/test/paragraph-properties.test.ts
@@ -114,6 +114,42 @@ describe('Paragraph formatting', () => {
 		);
 	});
 
+	describe('lineRule "exact"', () => {
+		test(
+			`<w:pPr ${ALL_NAMESPACE_DECLARATIONS}>
+				<w:spacing w:line="240" w:lineRule="exact" />
+			</w:pPr>`,
+			{
+				spacing: {
+					before: null,
+					after: null,
+					line: twip(240),
+					lineRule: 'exact',
+					afterAutoSpacing: false,
+					beforeAutoSpacing: false,
+				},
+			}
+		);
+	});
+
+	describe('lineRule "atLeast"', () => {
+		test(
+			`<w:pPr ${ALL_NAMESPACE_DECLARATIONS}>
+				<w:spacing w:line="240" w:lineRule="atLeast" />
+			</w:pPr>`,
+			{
+				spacing: {
+					before: null,
+					after: null,
+					line: twip(240),
+					lineRule: 'atLeast',
+					afterAutoSpacing: false,
+					beforeAutoSpacing: false,
+				},
+			}
+		);
+	});
+
 	describe('Legacy "left"/"right"', () => {
 		test(
 			`<w:pPr ${ALL_NAMESPACE_DECLARATIONS}>

--- a/lib/properties/test/paragraph-properties.test.ts
+++ b/lib/properties/test/paragraph-properties.test.ts
@@ -114,41 +114,25 @@ describe('Paragraph formatting', () => {
 		);
 	});
 
-	describe('lineRule "exact"', () => {
-		test(
-			`<w:pPr ${ALL_NAMESPACE_DECLARATIONS}>
-				<w:spacing w:line="240" w:lineRule="exact" />
-			</w:pPr>`,
-			{
-				spacing: {
-					before: null,
-					after: null,
-					line: twip(240),
-					lineRule: 'exact',
-					afterAutoSpacing: false,
-					beforeAutoSpacing: false,
-				},
-			}
-		);
-	});
-
-	describe('lineRule "atLeast"', () => {
-		test(
-			`<w:pPr ${ALL_NAMESPACE_DECLARATIONS}>
-				<w:spacing w:line="240" w:lineRule="atLeast" />
-			</w:pPr>`,
-			{
-				spacing: {
-					before: null,
-					after: null,
-					line: twip(240),
-					lineRule: 'atLeast',
-					afterAutoSpacing: false,
-					beforeAutoSpacing: false,
-				},
-			}
-		);
-	});
+	for (const lineRule of [null, 'exact', 'atLeast', 'auto'] as const) {
+		describe(`lineRule "${lineRule}"`, () => {
+			test(
+				`<w:pPr ${ALL_NAMESPACE_DECLARATIONS}>
+					<w:spacing w:line="240"${lineRule ? ` w:lineRule="${lineRule}"` : ''} />
+				</w:pPr>`,
+				{
+					spacing: {
+						before: null,
+						after: null,
+						line: twip(240),
+						lineRule,
+						afterAutoSpacing: false,
+						beforeAutoSpacing: false,
+					},
+				}
+			);
+		});
+	}
 
 	describe('Legacy "left"/"right"', () => {
 		test(


### PR DESCRIPTION
According to the official OOXML specification, the valid value is `exact` (see https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_ST_LineSpacingRule_topic_ID0ERZ42.html ), but the OOXML documentation contains some ambiguity, as in certain sections the term exactly is mentioned (see https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_spacing_topic_ID0EA1OM.html).  As a result, this led to set `exactly` as a possible value which it has no effect because it is not recognized as a valid value by the specification. That's why `exactly` is replaced with `exact` 